### PR TITLE
Add bilingual language support with Vietnamese translations

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,37 +1,44 @@
 import { Link } from 'react-router-dom';
+import { useLanguage } from '../context/LanguageContext.jsx';
 
 const Footer = () => {
+  const { t } = useLanguage();
   return (
     <footer className="mt-20 bg-slate-900 py-12 text-slate-200">
       <div className="mx-auto grid max-w-6xl gap-10 px-4 md:grid-cols-4">
         <div>
           <h3 className="font-display text-xl font-semibold text-white">SciBridge</h3>
-          <p className="mt-3 text-sm text-slate-300">
-            Bridging science learning and English support for high school students around the world.
-          </p>
+          <p className="mt-3 text-sm text-slate-300">{t(
+            'footer.description',
+            'Bridging science learning and English support for high school students around the world.'
+          )}</p>
         </div>
         <div>
-          <h4 className="text-sm font-semibold uppercase tracking-wide text-slate-400">Explore</h4>
+          <h4 className="text-sm font-semibold uppercase tracking-wide text-slate-400">
+            {t('footer.explore', 'Explore')}
+          </h4>
           <ul className="mt-3 space-y-2 text-sm">
             <li>
               <Link to="/subjects" className="hover:text-brand">
-                Subjects
+                {t('footer.subjects', 'Subjects')}
               </Link>
             </li>
             <li>
               <Link to="/quizzes" className="hover:text-brand">
-                Quizzes
+                {t('footer.quizzes', 'Quizzes')}
               </Link>
             </li>
             <li>
               <Link to="/resources" className="hover:text-brand">
-                Resources
+                {t('footer.resources', 'Resources')}
               </Link>
             </li>
           </ul>
         </div>
         <div>
-          <h4 className="text-sm font-semibold uppercase tracking-wide text-slate-400">Contact</h4>
+          <h4 className="text-sm font-semibold uppercase tracking-wide text-slate-400">
+            {t('footer.contact', 'Contact')}
+          </h4>
           <ul className="mt-3 space-y-2 text-sm">
             <li>Email: hello@scibridge.edu</li>
             <li>Phone: +1 (555) 123-4567</li>
@@ -39,27 +46,33 @@ const Footer = () => {
           </ul>
         </div>
         <div>
-          <h4 className="text-sm font-semibold uppercase tracking-wide text-slate-400">Stay Curious</h4>
+          <h4 className="text-sm font-semibold uppercase tracking-wide text-slate-400">
+            {t('footer.stayCurious', 'Stay Curious')}
+          </h4>
           <p className="mt-3 text-sm text-slate-300">
-            Subscribe for updates about new lessons, live events, and teacher tips.
+            {t('footer.subscribe', 'Subscribe for updates about new lessons, live events, and teacher tips.')}
           </p>
           <form className="mt-3 flex gap-2">
             <input
               type="email"
               className="flex-1 rounded-full border border-slate-700 bg-slate-800 px-4 py-2 text-sm text-white placeholder:text-slate-500 focus:border-brand focus:outline-none"
-              placeholder="Email address"
-              aria-label="Email address"
+              placeholder={t('footer.emailPlaceholder', 'Email address')}
+              aria-label={t('footer.emailPlaceholder', 'Email address')}
             />
             <button
               type="button"
               className="rounded-full bg-brand px-4 py-2 text-sm font-semibold text-white shadow hover:bg-brand-dark"
             >
-              Join
+              {t('footer.join', 'Join')}
             </button>
           </form>
         </div>
       </div>
-      <p className="mt-10 text-center text-xs text-slate-500">© {new Date().getFullYear()} SciBridge. All rights reserved.</p>
+      <p className="mt-10 text-center text-xs text-slate-500">
+        {t('footer.rights', `© ${new Date().getFullYear()} SciBridge. All rights reserved.`, {
+          year: new Date().getFullYear()
+        })}
+      </p>
     </footer>
   );
 };

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,29 +1,36 @@
 import { Link } from 'react-router-dom';
+import { useLanguage } from '../context/LanguageContext.jsx';
 
 const Hero = () => {
+  const { t } = useLanguage();
+
   return (
     <section className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-brand-light via-white to-accent-light px-6 py-16 shadow-lg">
       <div className="relative z-10 mx-auto max-w-3xl text-center">
-        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-dark">English-first learning</p>
+        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-dark">
+          {t('hero.eyebrow', 'English-first learning')}
+        </p>
         <h1 className="mt-4 font-display text-4xl font-semibold text-slate-900 md:text-5xl">
-          Master English to unlock every science story
+          {t('hero.heading', 'Master English to unlock every science story')}
         </h1>
         <p className="mt-4 text-base text-slate-600 md:text-lg">
-          Start with Academic English for Science, then extend your skills to Physics, Chemistry, Biology, and Earth Science.
-          Learn with visuals, short videos, interactive quizzes, and vocabulary adapted from Oxford and Cambridge resources.
+          {t(
+            'hero.description',
+            'Start with Academic English for Science, then extend your skills to Physics, Chemistry, Biology, and Earth Science. Learn with visuals, short videos, interactive quizzes, and vocabulary adapted from Oxford and Cambridge resources.'
+          )}
         </p>
         <div className="mt-8 flex flex-wrap items-center justify-center gap-4">
           <Link
             to="/subjects"
             className="rounded-full bg-brand px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-brand/30 transition hover:bg-brand-dark"
           >
-            Explore subjects
+            {t('hero.primaryCta', 'Explore subjects')}
           </Link>
           <Link
             to="/quizzes"
             className="rounded-full border border-brand bg-white px-6 py-3 text-sm font-semibold text-brand transition hover:bg-brand-light/60"
           >
-            Try a quiz
+            {t('hero.secondaryCta', 'Try a quiz')}
           </Link>
         </div>
       </div>

--- a/src/components/LessonCard.jsx
+++ b/src/components/LessonCard.jsx
@@ -1,20 +1,25 @@
 import { Link } from 'react-router-dom';
 import { FiBookOpen, FiCheckCircle } from 'react-icons/fi';
+import { useLanguage } from '../context/LanguageContext.jsx';
 
 const LessonCard = ({ lesson, subjectId, isCompleted, onComplete }) => {
+  const { t } = useLanguage();
+  const title = t(['lessons', subjectId, lesson.id, 'title'], lesson.title);
+  const summary = t(['lessons', subjectId, lesson.id, 'summary'], lesson.summary);
+  const keyVocabulary = t(['lessons', subjectId, lesson.id, 'keyVocabulary'], lesson.keyVocabulary);
   return (
     <article className="flex flex-col gap-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
       <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-        <h3 className="text-lg font-semibold text-slate-900">{lesson.title}</h3>
+        <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
         <div className="flex items-center gap-2 text-xs text-slate-500">
           <FiBookOpen aria-hidden />
-          <span>{lesson.keyVocabulary.length} key words</span>
+          <span>{t('lessonCard.keyWords', `${keyVocabulary.length} key words`, { count: keyVocabulary.length })}</span>
         </div>
       </div>
-      <p className="text-sm text-slate-600">{lesson.summary}</p>
-      <img src={lesson.image} alt={lesson.title} className="h-40 w-full object-cover" />
+      <p className="text-sm text-slate-600">{summary}</p>
+      <img src={lesson.image} alt={title} className="h-40 w-full object-cover" />
       <div className="flex flex-wrap gap-2 text-xs text-brand">
-        {lesson.keyVocabulary.map((word) => (
+        {keyVocabulary.map((word) => (
           <span key={word} className="rounded-full bg-brand-light/60 px-3 py-1 text-brand-dark">
             {word}
           </span>
@@ -25,7 +30,7 @@ const LessonCard = ({ lesson, subjectId, isCompleted, onComplete }) => {
           to={`/subjects/${subjectId}/lessons/${lesson.id}`}
           className="inline-flex items-center gap-2 text-sm font-semibold text-brand hover:text-brand-dark"
         >
-          View lesson
+          {t('lessonCard.viewLesson', 'View lesson')}
         </Link>
         <button
           onClick={() => onComplete?.(lesson.id)}
@@ -34,7 +39,7 @@ const LessonCard = ({ lesson, subjectId, isCompleted, onComplete }) => {
           }`}
         >
           <FiCheckCircle aria-hidden />
-          {isCompleted ? 'Completed' : 'Mark as completed'}
+          {isCompleted ? t('lessonCard.completed', 'Completed') : t('lessonCard.markCompleted', 'Mark as completed')}
         </button>
       </div>
     </article>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,26 +1,31 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Link, NavLink, useNavigate } from 'react-router-dom';
-import { FiMenu, FiX, FiSearch } from 'react-icons/fi';
+import { FiMenu, FiX, FiSearch, FiGlobe } from 'react-icons/fi';
+import { useLanguage } from '../context/LanguageContext.jsx';
 
 const baseNavItems = [
-  { path: '/', label: 'Home' },
-  { path: '/subjects', label: 'Subjects' },
-  { path: '/quizzes', label: 'Interactive Quizzes' },
-  { path: '/forum', label: 'Forum' },
-  { path: '/resources', label: 'Resources' },
-  { path: '/about', label: 'About' },
-  { path: '/contact', label: 'Contact' }
+  { path: '/', labelKey: 'navbar.home', defaultLabel: 'Home' },
+  { path: '/subjects', labelKey: 'navbar.subjects', defaultLabel: 'Subjects' },
+  { path: '/quizzes', labelKey: 'navbar.quizzes', defaultLabel: 'Interactive Quizzes' },
+  { path: '/forum', labelKey: 'navbar.forum', defaultLabel: 'Forum' },
+  { path: '/resources', labelKey: 'navbar.resources', defaultLabel: 'Resources' },
+  { path: '/about', labelKey: 'navbar.about', defaultLabel: 'About' },
+  { path: '/contact', labelKey: 'navbar.contact', defaultLabel: 'Contact' }
 ];
 
 const Navbar = ({ onSearch, user, onLogout }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [query, setQuery] = useState('');
   const navigate = useNavigate();
+  const { t, language, toggleLanguage } = useLanguage();
 
-  const navItems = [...baseNavItems];
-  if (user?.role === 'admin' || user?.role === 'teacher') {
-    navItems.splice(3, 0, { path: '/admin', label: 'Admin Panel' });
-  }
+  const navItems = useMemo(() => {
+    const items = [...baseNavItems];
+    if (user?.role === 'admin' || user?.role === 'teacher') {
+      items.splice(3, 0, { path: '/admin', labelKey: 'navbar.admin', defaultLabel: 'Admin Panel' });
+    }
+    return items;
+  }, [user]);
 
   const handleSubmit = (event) => {
     event.preventDefault();
@@ -49,7 +54,7 @@ const Navbar = ({ onSearch, user, onLogout }) => {
                 `text-sm font-semibold transition-colors hover:text-brand ${isActive ? 'text-brand-dark' : 'text-slate-600'}`
               }
             >
-              {item.label}
+              {t(item.labelKey, item.defaultLabel)}
             </NavLink>
           ))}
           <form onSubmit={handleSubmit} className="relative">
@@ -59,15 +64,27 @@ const Navbar = ({ onSearch, user, onLogout }) => {
               value={query}
               onChange={(event) => setQuery(event.target.value)}
               className="w-48 rounded-full border border-slate-200 bg-slate-50 py-2 pl-9 pr-4 text-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30"
-              placeholder="Search lessons"
-              aria-label="Search lessons"
+              placeholder={t('navbar.searchPlaceholder', 'Search lessons')}
+              aria-label={t('navbar.searchAria', 'Search lessons')}
             />
           </form>
+          <button
+            type="button"
+            onClick={() => {
+              toggleLanguage();
+              setIsOpen(false);
+            }}
+            className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-600 transition hover:border-brand hover:text-brand-dark"
+            aria-label={t('navbar.languageToggle', 'Switch language')}
+          >
+            <FiGlobe aria-hidden />
+            {language === 'en' ? 'EN' : 'VI'}
+          </button>
           {user ? (
             <div className="flex items-center gap-3 rounded-full bg-brand-light/60 px-3 py-1 text-sm font-semibold text-brand-dark">
-              <span className="hidden lg:inline">Hi, {user.name}</span>
+              <span className="hidden lg:inline">{t('navbar.greeting', `Hi, {name}`, { name: user.name })}</span>
               <span className="rounded-full bg-white/80 px-2 py-0.5 text-xs font-semibold capitalize text-brand-dark">
-                {user.role}
+                {t('navbar.role', 'Role')}: {user.role}
               </span>
               <button
                 type="button"
@@ -77,7 +94,7 @@ const Navbar = ({ onSearch, user, onLogout }) => {
                   setIsOpen(false);
                 }}
               >
-                Sign out
+                {t('navbar.signOut', 'Sign out')}
               </button>
             </div>
           ) : (
@@ -85,7 +102,7 @@ const Navbar = ({ onSearch, user, onLogout }) => {
               to="/forum"
               className="rounded-full bg-brand px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-dark"
             >
-              Join Forum
+              {t('navbar.joinForum', 'Join Forum')}
             </NavLink>
           )}
         </div>
@@ -106,8 +123,8 @@ const Navbar = ({ onSearch, user, onLogout }) => {
               value={query}
               onChange={(event) => setQuery(event.target.value)}
               className="w-full rounded-full border border-slate-200 bg-slate-50 py-2 pl-9 pr-4 text-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30"
-              placeholder="Search lessons"
-              aria-label="Search lessons"
+              placeholder={t('navbar.searchPlaceholder', 'Search lessons')}
+              aria-label={t('navbar.searchAria', 'Search lessons')}
             />
           </form>
           <div className="flex flex-col gap-3">
@@ -122,9 +139,23 @@ const Navbar = ({ onSearch, user, onLogout }) => {
                   }`
                 }
               >
-                {item.label}
+                {t(item.labelKey, item.defaultLabel)}
               </NavLink>
             ))}
+            <button
+              type="button"
+              onClick={() => {
+                toggleLanguage();
+                setIsOpen(false);
+              }}
+              className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-left text-sm font-semibold text-slate-600 hover:border-brand hover:text-brand-dark"
+            >
+              <span className="inline-flex items-center gap-2">
+                <FiGlobe aria-hidden />
+                {t('navbar.languageToggle', 'Switch language')}
+              </span>
+              <span className="mt-1 block text-xs uppercase tracking-wide text-slate-400">{language === 'en' ? 'English' : 'Tiếng Việt'}</span>
+            </button>
             {user ? (
               <button
                 type="button"
@@ -134,7 +165,7 @@ const Navbar = ({ onSearch, user, onLogout }) => {
                 }}
                 className="rounded-lg bg-brand-dark px-3 py-2 text-left text-sm font-semibold text-white shadow-sm hover:bg-brand"
               >
-                Sign out {user.name}
+                {t('navbar.signOutWithName', 'Sign out {name}', { name: user.name })}
               </button>
             ) : (
               <NavLink
@@ -142,7 +173,7 @@ const Navbar = ({ onSearch, user, onLogout }) => {
                 onClick={() => setIsOpen(false)}
                 className="rounded-lg bg-brand px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-dark"
               >
-                Join the Forum
+                {t('navbar.joinForumMobile', 'Join the Forum')}
               </NavLink>
             )}
           </div>

--- a/src/components/ProgressTracker.jsx
+++ b/src/components/ProgressTracker.jsx
@@ -1,14 +1,22 @@
+import { useLanguage } from '../context/LanguageContext.jsx';
+
 const ProgressTracker = ({ progress, totalLessons, onReset }) => {
+  const { t } = useLanguage();
   const completedCount = Object.keys(progress).length;
   const percentage = totalLessons ? Math.round((completedCount / totalLessons) * 100) : 0;
 
   return (
     <section className="flex flex-col gap-4 rounded-3xl border border-emerald-200 bg-emerald-50 p-6 text-emerald-700">
       <div>
-        <p className="text-xs font-semibold uppercase tracking-wide">Learning Progress</p>
-        <h3 className="mt-2 text-2xl font-display font-semibold">{percentage}% complete</h3>
+        <p className="text-xs font-semibold uppercase tracking-wide">{t('progress.title', 'Learning Progress')}</p>
+        <h3 className="mt-2 text-2xl font-display font-semibold">
+          {t('progress.percentage', `${percentage}% complete`, { percentage })}
+        </h3>
         <p className="mt-1 text-sm text-emerald-700/80">
-          You have finished {completedCount} of {totalLessons} lessons. Keep going!
+          {t('progress.summary', `You have finished ${completedCount} of ${totalLessons} lessons. Keep going!`, {
+            completed: completedCount,
+            total: totalLessons
+          })}
         </p>
       </div>
       <div className="h-3 w-full rounded-full bg-emerald-100">
@@ -21,7 +29,7 @@ const ProgressTracker = ({ progress, totalLessons, onReset }) => {
         onClick={onReset}
         className="self-start rounded-full bg-white px-4 py-2 text-xs font-semibold text-emerald-600 shadow-sm hover:bg-emerald-100"
       >
-        Reset progress
+        {t('progress.reset', 'Reset progress')}
       </button>
     </section>
   );

--- a/src/components/QuizCard.jsx
+++ b/src/components/QuizCard.jsx
@@ -1,12 +1,22 @@
 import { useState } from 'react';
 import { FiCheckCircle, FiXCircle } from 'react-icons/fi';
+import { useLanguage } from '../context/LanguageContext.jsx';
 
 const QuizCard = ({ quiz }) => {
+  const { t } = useLanguage();
   const [currentQuestion, setCurrentQuestion] = useState(0);
   const [selectedOption, setSelectedOption] = useState(null);
   const [isCorrect, setIsCorrect] = useState(null);
 
   const question = quiz.questions[currentQuestion];
+  const title = t(['quizzes', quiz.id, 'title'], quiz.title);
+  const description = t(['quizzes', quiz.id, 'description'], quiz.description);
+  const prompt = t(['quizzes', quiz.id, 'questions', currentQuestion, 'prompt'], question.prompt);
+  const options = t(['quizzes', quiz.id, 'questions', currentQuestion, 'options'], question.options);
+  const explanation = t(
+    ['quizzes', quiz.id, 'questions', currentQuestion, 'explanation'],
+    question.explanation
+  );
 
   const handleOptionClick = (index) => {
     setSelectedOption(index);
@@ -23,14 +33,16 @@ const QuizCard = ({ quiz }) => {
   return (
     <section className="flex flex-col gap-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
       <div className="flex flex-col gap-2">
-        <h3 className="text-lg font-semibold text-slate-900">{quiz.title}</h3>
-        <p className="text-sm text-slate-600">{quiz.description}</p>
+        <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
+        <p className="text-sm text-slate-600">{description}</p>
       </div>
       <div className="rounded-2xl bg-slate-50 p-4">
-        <p className="text-sm font-semibold text-brand">Question {currentQuestion + 1}</p>
-        <p className="mt-2 text-base font-medium text-slate-900">{question.prompt}</p>
+        <p className="text-sm font-semibold text-brand">
+          {t('quizzesPage.questionLabel', `Question {index}`, { index: currentQuestion + 1 })}
+        </p>
+        <p className="mt-2 text-base font-medium text-slate-900">{prompt}</p>
         <ul className="mt-4 space-y-3">
-          {question.options.map((option, index) => {
+          {options.map((option, index) => {
             const isSelected = selectedOption === index;
             const isAnswer = question.answerIndex === index;
             const statusClass =
@@ -63,7 +75,7 @@ const QuizCard = ({ quiz }) => {
               isCorrect ? 'bg-emerald-50 text-emerald-700' : 'bg-rose-50 text-rose-600'
             }`}
           >
-            {question.explanation}
+            {explanation}
           </div>
         )}
       </div>
@@ -72,7 +84,7 @@ const QuizCard = ({ quiz }) => {
           onClick={handleNext}
           className="rounded-full bg-brand px-4 py-2 text-sm font-semibold text-white shadow hover:bg-brand-dark"
         >
-          Next question
+          {t('quizzesPage.nextQuestion', 'Next question')}
         </button>
       </div>
     </section>

--- a/src/components/ResourceCard.jsx
+++ b/src/components/ResourceCard.jsx
@@ -1,15 +1,19 @@
+import { useLanguage } from '../context/LanguageContext.jsx';
+
 const ResourceCard = ({ resource }) => {
+  const { t } = useLanguage();
+  const description = t(['resources', resource.id, 'description'], resource.description);
   return (
     <article className="flex flex-col gap-3 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
       <h3 className="text-lg font-semibold text-slate-900">{resource.title}</h3>
-      <p className="text-sm text-slate-600">{resource.description}</p>
+      <p className="text-sm text-slate-600">{description}</p>
       <a
         href={resource.url}
         target="_blank"
         rel="noreferrer"
         className="text-sm font-semibold text-brand hover:text-brand-dark"
       >
-        Visit resource
+        {t('resourcesPage.visit', 'Visit resource')}
       </a>
     </article>
   );

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1,6 +1,8 @@
 import { FiSearch } from 'react-icons/fi';
+import { useLanguage } from '../context/LanguageContext.jsx';
 
 const SearchBar = ({ query, setQuery, placeholder = 'Search topics or keywords', onSubmit }) => {
+  const { t } = useLanguage();
   const handleSubmit = (event) => {
     event.preventDefault();
     onSubmit?.(query);
@@ -16,15 +18,15 @@ const SearchBar = ({ query, setQuery, placeholder = 'Search topics or keywords',
         value={query}
         onChange={(event) => setQuery(event.target.value)}
         type="search"
-        placeholder={placeholder}
-        aria-label={placeholder}
+        placeholder={t('searchBar.placeholder', placeholder)}
+        aria-label={t('searchBar.placeholder', placeholder)}
         className="w-full bg-transparent text-sm focus:outline-none"
       />
       <button
         type="submit"
         className="rounded-full bg-brand px-4 py-2 text-sm font-semibold text-white shadow hover:bg-brand-dark"
       >
-        Search
+        {t('searchBar.submit', 'Search')}
       </button>
     </form>
   );

--- a/src/components/SubjectCard.jsx
+++ b/src/components/SubjectCard.jsx
@@ -1,18 +1,23 @@
 import { Link } from 'react-router-dom';
 import { FiArrowRight } from 'react-icons/fi';
+import { useLanguage } from '../context/LanguageContext.jsx';
 
 const SubjectCard = ({ subject }) => {
+  const { t } = useLanguage();
+  const title = t(['subjects', subject.id, 'title'], subject.title);
+  const description = t(['subjects', subject.id, 'description'], subject.description);
+  const keywords = t(['subjects', subject.id, 'keywords'], subject.keywords);
   return (
     <article className="group flex flex-col overflow-hidden rounded-3xl bg-gradient-to-br p-[1px] shadow-lg transition hover:shadow-xl"
       style={{ backgroundImage: `linear-gradient(135deg, rgba(56,189,248,0.4), rgba(236,72,153,0.4))` }}
     >
       <div className="flex flex-1 flex-col gap-4 rounded-[calc(1.5rem-1px)] bg-white p-6">
-        <img src={subject.heroImage} alt={`${subject.title} illustration`} className="h-48 w-full object-cover" />
+        <img src={subject.heroImage} alt={`${title} illustration`} className="h-48 w-full object-cover" />
         <div className="flex flex-1 flex-col">
-          <h3 className="text-xl font-semibold text-slate-900">{subject.title}</h3>
-          <p className="mt-2 flex-1 text-sm text-slate-600">{subject.description}</p>
+          <h3 className="text-xl font-semibold text-slate-900">{title}</h3>
+          <p className="mt-2 flex-1 text-sm text-slate-600">{description}</p>
           <div className="mt-4 flex flex-wrap gap-2 text-xs font-medium text-brand">
-            {subject.keywords.map((keyword) => (
+            {keywords.map((keyword) => (
               <span key={keyword} className="rounded-full bg-brand-light/60 px-3 py-1 text-brand-dark">
                 {keyword}
               </span>
@@ -23,7 +28,7 @@ const SubjectCard = ({ subject }) => {
           to={`/subjects/${subject.id}`}
           className="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-brand transition group-hover:gap-3"
         >
-          Explore lessons
+          {t(['subjects', subject.id, 'cta'], 'Explore lessons')}
           <FiArrowRight aria-hidden />
         </Link>
       </div>

--- a/src/components/WordOfDay.jsx
+++ b/src/components/WordOfDay.jsx
@@ -1,20 +1,33 @@
 import { useMemo } from 'react';
 import { scienceWords } from '../data/words';
+import { useLanguage } from '../context/LanguageContext.jsx';
 
 const WordOfDay = () => {
+  const { t } = useLanguage();
   const word = useMemo(() => {
     const index = new Date().getDate() % scienceWords.length;
     return scienceWords[index];
   }, []);
 
+  const localizedTerm = t(['words', word.id, 'term'], word.term);
+  const localizedDefinition = t(['words', word.id, 'definition'], word.definition);
+  const localizedExample = t(['words', word.id, 'example'], word.example);
+  const localizedSource = t(['words', word.id, 'source'], word.source);
+
   return (
     <section className="rounded-3xl border border-brand/30 bg-brand-light/60 p-6">
-      <p className="text-xs font-semibold uppercase tracking-wide text-brand-dark">Word of the Day</p>
-      <h3 className="mt-2 text-2xl font-display font-semibold text-brand-dark">{word.term}</h3>
-      <p className="mt-3 text-sm text-slate-700">{word.definition}</p>
-      <p className="mt-2 text-sm italic text-brand-dark/80">Example: {word.example}</p>
-      {word.source && (
-        <p className="mt-2 text-xs text-slate-500">Definition adapted from {word.source}.</p>
+      <p className="text-xs font-semibold uppercase tracking-wide text-brand-dark">
+        {t('wordOfDay.eyebrow', 'Word of the Day')}
+      </p>
+      <h3 className="mt-2 text-2xl font-display font-semibold text-brand-dark">{localizedTerm}</h3>
+      <p className="mt-3 text-sm text-slate-700">{localizedDefinition}</p>
+      <p className="mt-2 text-sm italic text-brand-dark/80">
+        {t('wordOfDay.example', `Example: {example}`, { example: localizedExample })}
+      </p>
+      {localizedSource && (
+        <p className="mt-2 text-xs text-slate-500">
+          {t('wordOfDay.definitionSource', 'Definition adapted from {source}.', { source: localizedSource })}
+        </p>
       )}
     </section>
   );

--- a/src/context/LanguageContext.jsx
+++ b/src/context/LanguageContext.jsx
@@ -1,0 +1,109 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { translations } from '../i18n/translations';
+
+const LanguageContext = createContext(null);
+
+const DEFAULT_LANGUAGE = 'en';
+
+const resolvePath = (path, dictionary) => {
+  if (!dictionary) {
+    return undefined;
+  }
+
+  const segments = Array.isArray(path)
+    ? path
+    : String(path)
+        .split('.')
+        .filter(Boolean);
+
+  return segments.reduce((value, segment) => {
+    if (value == null) {
+      return undefined;
+    }
+    const key = typeof segment === 'number' || /^[0-9]+$/.test(segment)
+      ? Number(segment)
+      : segment;
+    return value?.[key];
+  }, dictionary);
+};
+
+const applyReplacements = (value, replacements) => {
+  if (!replacements || typeof value !== 'string') {
+    return value;
+  }
+
+  return Object.entries(replacements).reduce(
+    (text, [placeholder, replacement]) =>
+      text.replaceAll(`{${placeholder}}`, replacement ?? ''),
+    value
+  );
+};
+
+export const LanguageProvider = ({ children }) => {
+  const [language, setLanguage] = useState(() => {
+    if (typeof window === 'undefined') {
+      return DEFAULT_LANGUAGE;
+    }
+    const stored = window.localStorage.getItem('scibridge-language');
+    return stored || DEFAULT_LANGUAGE;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    window.localStorage.setItem('scibridge-language', language);
+  }, [language]);
+
+  const translate = useCallback(
+    (path, fallback, replacements) => {
+      const rawValue =
+        resolvePath(path, translations[language]) ??
+        resolvePath(path, translations[DEFAULT_LANGUAGE]);
+
+      if (Array.isArray(rawValue)) {
+        return rawValue.map((entry) =>
+          typeof entry === 'string' ? applyReplacements(entry, replacements) : entry
+        );
+      }
+
+      if (rawValue !== undefined) {
+        return applyReplacements(rawValue, replacements);
+      }
+
+      if (Array.isArray(fallback)) {
+        return fallback.map((entry) =>
+          typeof entry === 'string' ? applyReplacements(entry, replacements) : entry
+        );
+      }
+
+      if (fallback !== undefined) {
+        return applyReplacements(fallback, replacements);
+      }
+
+      return undefined;
+    },
+    [language]
+  );
+
+  const value = useMemo(
+    () => ({
+      language,
+      setLanguage,
+      toggleLanguage: () => setLanguage((previous) => (previous === 'en' ? 'vi' : 'en')),
+      t: translate
+    }),
+    [language, translate]
+  );
+
+  return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;
+};
+
+export const useLanguage = () => {
+  const context = useContext(LanguageContext);
+  if (!context) {
+    throw new Error('useLanguage must be used within a LanguageProvider');
+  }
+  return context;
+};
+

--- a/src/data/words.js
+++ b/src/data/words.js
@@ -5,6 +5,7 @@
  */
 export const scienceWords = [
   {
+    id: 'hypothesis',
     term: 'hypothesis',
     definition:
       'An idea or explanation based on known facts that scientists still need to test to discover if it is true.',
@@ -12,6 +13,7 @@ export const scienceWords = [
     source: "Oxford Learner's Dictionaries"
   },
   {
+    id: 'photosynthesis',
     term: 'photosynthesis',
     definition:
       'The process that lets plants use energy from sunlight to make their own food.',
@@ -19,18 +21,21 @@ export const scienceWords = [
     source: 'Cambridge Dictionary'
   },
   {
+    id: 'velocity',
     term: 'velocity',
     definition: 'The speed at which something moves in a particular direction.',
     example: 'The car has a velocity of 60 kilometers per hour to the north.',
     source: 'Cambridge Dictionary'
   },
   {
+    id: 'molecule',
     term: 'molecule',
     definition: 'The smallest unit of a substance that is made of two or more atoms joined together.',
     example: 'A water molecule has two hydrogen atoms and one oxygen atom.',
     source: "Oxford Learner's Dictionaries"
   },
   {
+    id: 'erosion',
     term: 'erosion',
     definition: 'The gradual wearing away of rock or soil by wind, water, or ice.',
     example: 'Ocean waves cause erosion that changes the shape of the coastline.',

--- a/src/i18n/translations.js
+++ b/src/i18n/translations.js
@@ -1,0 +1,627 @@
+export const translations = {
+  en: {
+    navbar: {
+      languageToggle: 'Switch language',
+      languageName: {
+        en: 'English',
+        vi: 'Vietnamese'
+      }
+    },
+    lessonsPage: {
+      lessonFound: 'lesson found',
+      lessonsFound: 'lessons found'
+    }
+  },
+  vi: {
+    navbar: {
+      home: 'Trang chủ',
+      subjects: 'Môn học',
+      quizzes: 'Bài kiểm tra tương tác',
+      forum: 'Diễn đàn',
+      resources: 'Tài nguyên',
+      about: 'Giới thiệu',
+      contact: 'Liên hệ',
+      admin: 'Bảng điều khiển',
+      joinForum: 'Tham gia diễn đàn',
+      joinForumMobile: 'Tham gia diễn đàn',
+      signOut: 'Đăng xuất',
+      signOutWithName: 'Đăng xuất {name}',
+      greeting: 'Xin chào, {name}',
+      role: 'Vai trò',
+      searchPlaceholder: 'Tìm kiếm bài học',
+      languageToggle: 'Chuyển đổi ngôn ngữ',
+      searchAria: 'Tìm kiếm bài học'
+    },
+    hero: {
+      eyebrow: 'Học tiếng Anh trước',
+      heading: 'Làm chủ tiếng Anh để khám phá mọi câu chuyện khoa học',
+      description:
+        'Bắt đầu với chương trình Tiếng Anh cho Khoa học, sau đó mở rộng kỹ năng sang Vật lý, Hóa học, Sinh học và Khoa học Trái Đất. Học với hình ảnh, video ngắn, bài kiểm tra tương tác và từ vựng được điều chỉnh từ nguồn Oxford và Cambridge.',
+      primaryCta: 'Khám phá môn học',
+      secondaryCta: 'Thử một bài kiểm tra'
+    },
+    home: {
+      tracksEyebrow: 'Lộ trình cốt lõi và mở rộng',
+      tracksHeading: 'Bắt đầu với tiếng Anh, sau đó mở rộng khám phá khoa học',
+      tracksDescription:
+        'Bắt đầu với chương trình Tiếng Anh cho Khoa học để luyện từ vựng, ngữ pháp và cụm từ thuyết trình. Khi tự tin, hãy tiếp tục với các mô-đun mở rộng về Vật lý, Hóa học, Sinh học và Khoa học Trái Đất — mỗi mô-đun đều có hình ảnh, video và thuật ngữ chính bằng tiếng Anh dễ hiểu.',
+      practiceEyebrow: 'Luyện tập tương tác',
+      forumHeading: 'Luyện tiếng Anh cùng bạn học',
+      forumDescription:
+        'Tham gia Diễn đàn SciBridge để chia sẻ cập nhật học tập, đặt câu hỏi bằng tiếng Anh và hỗ trợ các bạn khác trong các môn Vật lý, Hóa học, Sinh học và Khoa học Trái Đất. Tạo tài khoản, xác minh email và đăng nhập để chia sẻ tiếng nói của bạn một cách an toàn.',
+      forumCta: 'Đến diễn đàn'
+    },
+    footer: {
+      description: 'Kết nối việc học khoa học và hỗ trợ tiếng Anh cho học sinh trung học trên toàn thế giới.',
+      explore: 'Khám phá',
+      subjects: 'Môn học',
+      quizzes: 'Bài kiểm tra',
+      resources: 'Tài nguyên',
+      contact: 'Liên hệ',
+      stayCurious: 'Luôn tò mò',
+      subscribe: 'Đăng ký để nhận thông tin về bài học mới, sự kiện trực tiếp và mẹo cho giáo viên.',
+      emailPlaceholder: 'Địa chỉ email',
+      join: 'Tham gia',
+      rights: '© {year} SciBridge. Đã đăng ký bản quyền.'
+    },
+    searchBar: {
+      placeholder: 'Tìm kiếm chủ đề hoặc từ khóa',
+      submit: 'Tìm kiếm'
+    },
+    subjectsPage: {
+      eyebrow: 'Học theo chủ đề',
+      heading: 'Bài học tiếng Anh cốt lõi và mở rộng khoa học',
+      description:
+        'Tìm kiếm các bài học Tiếng Anh cho Khoa học trước, sau đó khám phá các mô-đun mở rộng về Vật lý, Hóa học, Sinh học và Khoa học Trái Đất. Phần giải thích sử dụng tiếng Anh học thuật đơn giản để hỗ trợ người học đa ngôn ngữ.',
+      searchPlaceholder: 'Tìm kiếm tiêu đề bài học, môn học hoặc từ khóa',
+      resultsSingular: 'Đã tìm thấy {count} bài học',
+      resultsPlural: 'Đã tìm thấy {count} bài học',
+      browseHeading: 'Khám phá chương trình tiếng Anh cốt lõi và mở rộng khoa học',
+      coreBadge: 'Môn tiếng Anh cốt lõi',
+      extensionBadge: 'Mô-đun mở rộng',
+      subjectNotFound: 'Không tìm thấy môn học',
+      subjectNotFoundMessage: 'Vui lòng quay lại trang môn học và chọn một chủ đề khác.',
+      lessonCollection: 'Bộ sưu tập bài học'
+    },
+    lessonCard: {
+      keyWords: '{count} từ khóa',
+      viewLesson: 'Xem bài học',
+      completed: 'Đã hoàn thành',
+      markCompleted: 'Đánh dấu đã hoàn thành'
+    },
+    progress: {
+      title: 'Tiến độ học tập',
+      percentage: '{percentage}% hoàn thành',
+      summary: 'Bạn đã hoàn thành {completed} trên {total} bài học. Tiếp tục nhé!',
+      reset: 'Đặt lại tiến độ'
+    },
+    lessonPage: {
+      notFoundTitle: 'Không tìm thấy bài học',
+      backToSubjects: 'Quay lại danh sách môn học',
+      breadcrumbSubjects: 'Môn học',
+      eyebrow: 'Bài học',
+      stepsHeading: 'Giải thích từng bước',
+      videoHeading: 'Xem bài học ngắn',
+      videoDescription: 'Video giúp bạn kết nối từ vựng tiếng Anh với hình ảnh khoa học. Hãy bật phụ đề để hỗ trợ việc học ngôn ngữ.',
+      animationHeading: 'Hoạt hình minh họa',
+      animationDescription: 'Sử dụng hình động để quan sát quá trình khoa học đang diễn ra.',
+      completed: 'Đã hoàn thành bài học',
+      markCompleted: 'Đánh dấu đã hoàn thành bài học',
+      practiceHeading: 'Ý tưởng luyện tập',
+      practiceList: [
+        'Viết các từ vựng chính vào vở khoa học. Ghi thêm định nghĩa ngắn bằng tiếng Anh.',
+        'Tóm tắt bài học trong ba câu. Tập trung vào ý chính và một ví dụ minh họa.',
+        'Giải thích cho bạn bè bằng hoạt hình. Trình bày từng bước bằng từ mới.'
+      ]
+    },
+    subjects: {
+      'english-for-science': {
+        title: 'Tiếng Anh cho Khoa học',
+        description:
+          'Xây dựng từ vựng, ngữ pháp và kỹ năng giao tiếp tiếng Anh học thuật để chia sẻ ý tưởng khoa học tự nhiên dễ dàng.',
+        keywords: ['từ vựng', 'ngữ pháp', 'giao tiếp'],
+        cta: 'Khám phá bài học',
+        overview:
+          'Tiếng Anh là môn học cốt lõi tại SciBridge. Các bài học giải thích cách đọc, viết và trình bày thí nghiệm bằng ngôn ngữ học thuật tự tin.'
+      },
+      physics: {
+        title: 'Vật lý',
+        description:
+          'Mở rộng: Vận dụng tiếng Anh để khám phá vật chất, năng lượng, chuyển động và lực trong vũ trụ.',
+        keywords: ['chuyển động', 'năng lượng', 'lực', 'sóng'],
+        cta: 'Khám phá bài học',
+        overview:
+          'Mở rộng kỹ năng Tiếng Anh cho Khoa học bằng cách tìm hiểu chuyển động, năng lượng, sóng và công nghệ với hình ảnh rõ ràng.'
+      },
+      chemistry: {
+        title: 'Hóa học (Mở rộng)',
+        description:
+          'Mở rộng: Sử dụng tiếng Anh học thuật để mô tả chất, phản ứng và cách các chất biến đổi, kết hợp.',
+        keywords: ['nguyên tử', 'phân tử', 'phản ứng'],
+        cta: 'Khám phá bài học',
+        overview:
+          'Mở rộng vốn từ vựng khi khám phá các thành phần cấu tạo vật chất, phản ứng hóa học và bảng tuần hoàn.'
+      },
+      biology: {
+        title: 'Sinh học (Mở rộng)',
+        description: 'Mở rộng: Tăng cường kỹ năng đọc viết tiếng Anh khi tìm hiểu sinh vật và hệ sinh thái.',
+        keywords: ['tế bào', 'hệ sinh thái', 'cơ quan'],
+        cta: 'Khám phá bài học',
+        overview:
+          'Mở rộng kỹ năng viết và đọc tiếng Anh bằng cách học về tế bào, hệ cơ quan và hệ sinh thái với lời giải thích thân thiện.'
+      },
+      'earth-science': {
+        title: 'Khoa học Trái Đất (Mở rộng)',
+        description: 'Mở rộng: Dùng tiếng Anh để giải thích Trái Đất, đá, thời tiết, khí hậu và các hiện tượng không gian.',
+        keywords: ['địa chất', 'thời tiết', 'khí hậu'],
+        cta: 'Khám phá bài học',
+        overview:
+          'Mở rộng khả năng hiểu tiếng Anh khi khám phá Trái Đất năng động, mô hình thời tiết và hệ Mặt Trời.'
+      }
+    },
+    lessons: {
+      'english-for-science': {
+        'language-of-experiments': {
+          title: 'Ngôn ngữ của thí nghiệm',
+          summary:
+            'Luyện động từ, từ chỉ trình tự và liên kết nhân quả để mô tả điều tra khoa học bằng tiếng Anh.',
+          keyVocabulary: ['giả thuyết', 'đo lường', 'vì thế'],
+          content: [
+            'Sử dụng những động từ hành động mạnh như đo, quan sát, so sánh, ghi chép khi mô tả từng bước thí nghiệm.',
+            'Các từ chỉ trình tự như đầu tiên, tiếp theo, rồi, cuối cùng giúp người đọc theo dõi thứ tự các bước.',
+            'Từ nối nguyên nhân – kết quả như bởi vì, do đó, vì thế cho thấy bằng chứng hỗ trợ kết luận.'
+          ]
+        },
+        'science-presentation-skills': {
+          title: 'Kỹ năng thuyết trình khoa học',
+          summary: 'Học cụm từ giúp trình bày khoa học rõ ràng, tự tin bằng tiếng Anh.',
+          keyVocabulary: ['chứng cứ', 'giải thích', 'tóm tắt'],
+          content: [
+            'Bắt đầu bài thuyết trình bằng câu hỏi, thông tin bất ngờ hoặc câu chuyện liên kết khoa học với đời sống hằng ngày.',
+            'Giải thích chứng cứ bằng câu đơn giản trước khi dùng từ vựng nâng cao. Giải nghĩa từ mới ngay lần đầu sử dụng.',
+            'Tóm tắt ý chính ở cuối và mời câu hỏi bằng cụm như “Bạn muốn tôi làm rõ bước nào không?”.'
+          ]
+        }
+      },
+      physics: {
+        'newton-laws': {
+          title: 'Định luật chuyển động của Newton',
+          summary: 'Hiểu cách vật chuyển động và lực làm thay đổi chuyển động bằng ví dụ đơn giản.',
+          keyVocabulary: ['quán tính', 'gia tốc', 'lực'],
+          content: [
+            'Newton mô tả ba quy tắc chuyển động giúp chúng ta dự đoán cách vật di chuyển.',
+            'Định luật một: Vật giữ nguyên trạng thái nếu không có lực tác dụng. Đó là quán tính.',
+            'Định luật hai: Lực mạnh hơn tạo gia tốc lớn hơn. Vật có khối lượng lớn cần lực lớn hơn để di chuyển.',
+            'Định luật ba: Mọi lực tác dụng đều có phản lực tương đương và ngược hướng. Lực luôn xuất hiện theo cặp.'
+          ]
+        },
+        'energy-forms': {
+          title: 'Các dạng năng lượng',
+          summary: 'Khám phá các dạng năng lượng như động năng, thế năng, nhiệt và điện.',
+          keyVocabulary: ['động năng', 'thế năng', 'nhiệt'],
+          content: [
+            'Năng lượng là khả năng sinh công hoặc tạo ra thay đổi. Năng lượng không tự sinh ra hay mất đi mà chỉ chuyển hóa.',
+            'Động năng là năng lượng của chuyển động. Thế năng là năng lượng dự trữ, ví dụ cuốn sách đặt trên giá.',
+            'Nhiệt năng đến từ chuyển động của hạt. Năng lượng điện truyền trong dây dẫn và cung cấp điện cho bóng đèn.'
+          ]
+        }
+      },
+      chemistry: {
+        'atomic-structure': {
+          title: 'Bên trong nguyên tử',
+          summary: 'Làm quen với proton, nơtron và electron, cách chúng tạo thành nguyên tử và nguyên tố khác nhau.',
+          keyVocabulary: ['proton', 'nơtron', 'electron'],
+          content: [
+            'Nguyên tử có tâm gọi là hạt nhân chứa proton mang điện dương và nơtron không mang điện.',
+            'Electron là hạt rất nhỏ mang điện âm, chuyển động quanh hạt nhân theo các mức năng lượng.',
+            'Nguyên tử khác nhau có số proton khác nhau. Số proton quyết định nguyên tố đó là gì.'
+          ]
+        },
+        'chemical-reactions': {
+          title: 'Phản ứng hóa học',
+          summary: 'Tìm hiểu cách chất biến đổi thành chất mới thông qua phá vỡ và hình thành liên kết hóa học.',
+          keyVocabulary: ['chất phản ứng', 'sản phẩm', 'bảo toàn'],
+          content: [
+            'Trong phản ứng hóa học, chất phản ứng biến đổi thành sản phẩm. Các nguyên tử được sắp xếp lại nhưng không mất đi.',
+            'Dấu hiệu phản ứng gồm đổi màu, thay đổi nhiệt độ, sinh khí hoặc tạo chất rắn mới.',
+            'Khối lượng chất phản ứng bằng khối lượng sản phẩm. Đây là định luật bảo toàn khối lượng.'
+          ]
+        }
+      },
+      biology: {
+        'cell-structure': {
+          title: 'Tế bào – đơn vị cơ bản của sự sống',
+          summary: 'Quan sát tế bào thực vật và động vật cùng các bào quan giúp tế bào hoạt động.',
+          keyVocabulary: ['nhân tế bào', 'màng tế bào', 'lục lạp'],
+          content: [
+            'Mọi sinh vật đều gồm các tế bào. Mỗi tế bào có bào quan đảm nhiệm công việc riêng.',
+            'Nhân tế bào điều khiển hoạt động. Màng tế bào bảo vệ tế bào. Tế bào thực vật có lục lạp để quang hợp.',
+            'Các tế bào phối hợp tạo mô, cơ quan và hệ cơ quan trong cơ thể sống.'
+          ]
+        },
+        ecosystems: {
+          title: 'Hệ sinh thái và dòng năng lượng',
+          summary: 'Xem cách sinh vật sản xuất, tiêu thụ và phân hủy tạo nên chuỗi và lưới thức ăn.',
+          keyVocabulary: ['sinh vật sản xuất', 'sinh vật tiêu thụ', 'sinh vật phân hủy'],
+          content: [
+            'Hệ sinh thái gồm các sinh vật và môi trường vô sinh. Mỗi thành phần đều liên kết với nhau.',
+            'Sinh vật sản xuất tạo thức ăn giàu năng lượng nhờ ánh sáng. Sinh vật tiêu thụ ăn thực vật hoặc động vật. Sinh vật phân hủy phân giải vật chết.',
+            'Năng lượng đi từ Mặt Trời tới sinh vật sản xuất rồi truyền sang sinh vật tiêu thụ. Lưới thức ăn thể hiện nhiều đường truyền năng lượng.'
+          ]
+        }
+      },
+      'earth-science': {
+        'rock-cycle': {
+          title: 'Chu trình đá',
+          summary: 'Tìm hiểu cách đá biến đổi qua nóng chảy, nguội đông, phong hóa và áp suất.',
+          keyVocabulary: ['đá magma', 'đá trầm tích', 'đá biến chất'],
+          content: [
+            'Đá luôn thay đổi trong chu trình đá. Nhiệt, áp suất và phong hóa làm đá biến đổi.',
+            'Đá magma hình thành khi dung nham nguội. Đá trầm tích tạo từ các lớp vật liệu nhỏ. Đá biến chất thay đổi dưới tác động nhiệt và áp suất.',
+            'Chu trình đá không có điểm bắt đầu hay kết thúc. Đá có thể trải qua nhiều giai đoạn nhiều lần.'
+          ]
+        },
+        'weather-climate': {
+          title: 'Thời tiết và khí hậu',
+          summary: 'Hiểu sự khác biệt giữa thời tiết hằng ngày và kiểu khí hậu dài hạn.',
+          keyVocabulary: ['nhiệt độ', 'lượng mưa', 'biến đổi khí hậu'],
+          content: [
+            'Thời tiết mô tả điều kiện ngắn hạn như nhiệt độ, gió và mưa. Khí hậu mô tả thời tiết trung bình trong nhiều năm.',
+            'Đai khí hậu có thể là nhiệt đới, ôn đới hay hàn đới. Chúng phụ thuộc vào vĩ độ và nhiều yếu tố khác.',
+            'Biến đổi khí hậu xảy ra khi mô hình dài hạn thay đổi. Hoạt động của con người có thể làm nhanh quá trình này.'
+          ]
+        }
+      }
+    },
+    quizzes: {
+      'english-for-science-quiz': {
+        title: 'Tiếng Anh giao tiếp khoa học',
+        description: 'Kiểm tra hiểu biết về cụm từ tiếng Anh dùng để giải thích thí nghiệm và dữ liệu.',
+        questions: [
+          {
+            prompt: 'Câu nào sử dụng từ chỉ trình tự rõ ràng?',
+            options: [
+              'Khuấy dung dịch cẩn thận.',
+              'Nhiệt độ đã tăng.',
+              'Đầu tiên, đo 10 mililit nước.',
+              'Chúng tôi học được rất nhiều từ thí nghiệm này.'
+            ],
+            explanation: 'Từ chỉ trình tự như “đầu tiên” giúp người nghe theo dõi thứ tự các bước thí nghiệm.'
+          },
+          {
+            prompt: 'Chọn cụm từ tốt nhất để giải thích nguyên nhân của kết quả.',
+            options: ['Kết luận lại', 'Do đó (as a result of)', 'Ví dụ', 'Tóm lại'],
+            explanation:
+              '“Do đó (as a result of)” liên kết chứng cứ với kết quả và thể hiện quan hệ nhân quả trong bài viết tiếng Anh.'
+          }
+        ]
+      },
+      'physics-quiz': {
+        title: 'Kiểm tra nhanh Vật lý (Mở rộng)',
+        description: 'Ôn luyện chuyển động, lực và năng lượng bằng tiếng Anh.',
+        questions: [
+          {
+            prompt: 'Từ nào mô tả xu hướng của vật chống lại thay đổi chuyển động?',
+            options: ['Động lượng', 'Quán tính', 'Ma sát', 'Vận tốc'],
+            explanation: 'Quán tính là xu hướng của vật chống lại thay đổi chuyển động.'
+          },
+          {
+            prompt: 'Dạng năng lượng nào được tích trữ do vị trí của vật?',
+            options: ['Thế năng', 'Nhiệt năng', 'Âm năng', 'Năng lượng hạt nhân'],
+            explanation: 'Thế năng là năng lượng tích trữ liên quan đến vị trí hoặc trạng thái của vật.'
+          }
+        ]
+      },
+      'chemistry-quiz': {
+        title: 'Kiểm tra cơ bản Hóa học (Mở rộng)',
+        description: 'Sử dụng từ vựng tiếng Anh để ôn nguyên tử, nguyên tố và phản ứng hóa học.',
+        questions: [
+          {
+            prompt: 'Hạt nào mang điện dương trong nguyên tử?',
+            options: ['Electron', 'Nơtron', 'Proton', 'Photon'],
+            explanation: 'Proton mang điện dương và nằm trong hạt nhân.'
+          },
+          {
+            prompt: 'Trong phản ứng hóa học, các chất ban đầu được gọi là gì?',
+            options: ['Sản phẩm', 'Chất phản ứng', 'Dung môi', 'Hỗn hợp'],
+            explanation: 'Chất phản ứng là vật chất ban đầu bị biến đổi trong phản ứng hóa học.'
+          }
+        ]
+      },
+      'biology-quiz': {
+        title: 'Kiểm tra Sinh học (Mở rộng)',
+        description: 'Luyện tiếng Anh khi kiểm tra các ý chính về tế bào và hệ sinh thái.',
+        questions: [
+          {
+            prompt: 'Bào quan nào điều khiển tế bào?',
+            options: ['Lục lạp', 'Nhân tế bào', 'Thành tế bào', 'Không bào'],
+            explanation: 'Nhân tế bào hoạt động như trung tâm điều khiển của tế bào.'
+          },
+          {
+            prompt: 'Sinh vật phân hủy làm gì trong hệ sinh thái?',
+            options: ['Tạo thức ăn từ ánh sáng', 'Phân hủy vật chết', 'Điều khiển khí hậu', 'Sản xuất oxy'],
+            explanation: 'Sinh vật phân hủy phân giải vật chết và tái chế chất dinh dưỡng về đất.'
+          }
+        ]
+      },
+      'earth-science-quiz': {
+        title: 'Khám phá Khoa học Trái Đất (Mở rộng)',
+        description: 'Giải thích đá, thời tiết và khí hậu bằng tiếng Anh trong khi ôn kiến thức khoa học.',
+        questions: [
+          {
+            prompt: 'Loại đá nào hình thành khi đá nóng chảy nguội đi và đông cứng?',
+            options: ['Đá trầm tích', 'Đá biến chất', 'Đá magma', 'Hóa thạch'],
+            explanation: 'Đá magma hình thành khi dung nham hoặc magma nguội và đông cứng.'
+          },
+          {
+            prompt: 'Khí hậu mô tả kiểu thời tiết trong khoảng thời gian bao lâu?',
+            options: ['Giờ', 'Ngày', 'Chỉ vài tháng', 'Nhiều năm'],
+            explanation: 'Khí hậu là điều kiện thời tiết trung bình trong nhiều năm.'
+          }
+        ]
+      }
+    },
+    words: {
+      hypothesis: {
+        term: 'hypothesis (giả thuyết)',
+        definition:
+          'Một ý tưởng hoặc lời giải thích dựa trên sự thật đã biết mà nhà khoa học cần kiểm tra để xem có đúng hay không.',
+        example: 'Giả thuyết của chúng tôi là cây sẽ phát triển nhanh hơn với ánh sáng xanh.',
+        source: 'Từ điển Oxford Learner'
+      },
+      photosynthesis: {
+        term: 'photosynthesis (quang hợp)',
+        definition: 'Quá trình giúp cây sử dụng năng lượng mặt trời để tự tạo thức ăn.',
+        example: 'Trong quang hợp, cây tạo đường và khí oxy.',
+        source: 'Từ điển Cambridge'
+      },
+      velocity: {
+        term: 'velocity (vận tốc)',
+        definition: 'Tốc độ mà một vật di chuyển theo một hướng xác định.',
+        example: 'Chiếc xe có vận tốc 60 ki-lô-mét một giờ về phía bắc.',
+        source: 'Từ điển Cambridge'
+      },
+      molecule: {
+        term: 'molecule (phân tử)',
+        definition: 'Đơn vị nhỏ nhất của một chất gồm hai hoặc nhiều nguyên tử liên kết với nhau.',
+        example: 'Phân tử nước gồm hai nguyên tử hiđrô và một nguyên tử ôxy.',
+        source: 'Từ điển Oxford Learner'
+      },
+      erosion: {
+        term: 'erosion (xói mòn)',
+        definition: 'Quá trình đất đá bị mài mòn dần bởi gió, nước hoặc băng.',
+        example: 'Sóng biển gây xói mòn làm thay đổi hình dạng đường bờ biển.',
+        source: 'Từ điển Cambridge'
+      }
+    },
+    quizzesPage: {
+      eyebrow: 'Bài kiểm tra tương tác',
+      heading: 'Dẫn dắt bằng tiếng Anh, ôn luyện khoa học',
+      description:
+        'Bắt đầu với bài kiểm tra Tiếng Anh cho Giao tiếp Khoa học, sau đó thử các bài kiểm tra mở rộng cho Vật lý, Hóa học, Sinh học và Khoa học Trái Đất. Đọc phần giải thích để củng cố từ vựng tiếng Anh học thuật.',
+      questionLabel: 'Câu hỏi {index}',
+      nextQuestion: 'Câu hỏi tiếp theo'
+    },
+    resourcesPage: {
+      eyebrow: 'Tài nguyên',
+      heading: 'Công cụ học tập bổ sung',
+      description:
+        'Khám phá các trang web an toàn cung cấp video, hoạt hình, bài viết và tài liệu tải xuống. Hãy dùng những công cụ này để ôn bài hoặc mở rộng việc học bằng tiếng Anh.',
+      visit: 'Truy cập tài nguyên'
+    },
+    homeForum: {
+      wordEyebrow: 'Từ vựng hôm nay',
+      chatbotTitle: 'Trợ lý khoa học',
+      chatbotDescription: 'Nhập từ khóa và nhận giải thích tiếng Anh đơn giản.'
+    },
+    wordOfDay: {
+      eyebrow: 'Từ vựng hôm nay',
+      example: 'Ví dụ: {example}',
+      definitionSource: 'Định nghĩa phỏng theo {source}'
+    },
+    chatbot: {
+      title: 'Chatbot trợ giúp khoa học',
+      description: 'Nhập từ khóa chủ đề và nhận lời giải thích bằng tiếng Anh đơn giản.',
+      placeholder: 'Hỏi về lực, nguyên tử, hệ sinh thái...',
+      send: 'Gửi',
+      welcome: 'Xin chào! Hãy hỏi tôi một câu hỏi khoa học bằng tiếng Anh. Tôi sẽ giải thích bằng ngôn ngữ dễ hiểu.',
+      responses: {
+        force:
+          'Lực là đẩy hoặc kéo. Lực có thể làm vật nhanh hơn, chậm lại hoặc đổi hướng chuyển động.',
+        atom:
+          'Nguyên tử là hạt rất nhỏ. Nguyên tử có hạt nhân gồm proton và neutron, các electron quay xung quanh hạt nhân.',
+        ecosystem:
+          'Hệ sinh thái là cộng đồng sinh vật và môi trường của chúng. Năng lượng đi từ sinh vật sản xuất đến sinh vật tiêu thụ rồi đến sinh vật phân hủy.',
+        climate:
+          'Thời tiết thay đổi hằng ngày. Khí hậu mô tả kiểu thời tiết dài hạn của một khu vực.',
+        fallback: 'Tôi vẫn đang học. Hãy thử hỏi về lực, nguyên tử, hệ sinh thái hoặc khí hậu nhé.'
+      }
+    },
+    quizCard: {
+      explanationCorrect: 'Chính xác',
+      explanationIncorrect: 'Chưa đúng'
+    },
+    resources: {
+      nasa: {
+        description: 'Bài viết, video và trò chơi sinh động giải thích các chủ đề Khoa học Trái Đất cho người học trẻ.'
+      },
+      physicsClassroom: {
+        description: 'Các bài giải thích tương tác, sơ đồ và câu hỏi luyện tập bao quát kiến thức Vật lý cốt lõi.'
+      },
+      khanChemistry: {
+        description: 'Video ngắn và bài tập về cấu trúc nguyên tử, liên kết và phản ứng hóa học.'
+      },
+      biodigital: {
+        description: 'Mô hình 3D và hoạt hình về cơ thể người hỗ trợ học Sinh học.'
+      }
+    },
+    aboutPage: {
+      eyebrow: 'Giới thiệu',
+      heading: 'Sứ mệnh của chúng tôi',
+      description1:
+        'SciBridge hỗ trợ học sinh trung học học Khoa học Tự nhiên bằng tiếng Anh. Chúng tôi kết hợp nội dung khoa học chính xác với phần giải thích thân thiện, hỗ trợ từ vựng và đa phương tiện để xây dựng sự tự tin. Mỗi bài học được viết bằng ngôn ngữ học thuật đơn giản để người học tiếng Anh có thể tham gia đầy đủ vào lớp khoa học.',
+      description2:
+        'Đội ngũ giảng dạy của chúng tôi gồm giáo viên khoa học, chuyên gia ngôn ngữ và nhà thiết kế. Chúng tôi cùng tạo ra các mô-đun học linh hoạt để giáo viên sử dụng trên lớp hoặc học sinh tự khám phá.',
+      expandHeading: 'Cách mở rộng trang web này',
+      expandList: [
+        'Bổ sung thêm bài học với ví dụ địa phương và tình huống phù hợp văn hóa.',
+        'Dịch các từ vựng quan trọng sang ngôn ngữ khác cho lớp học đa ngôn ngữ.',
+        'Tạo tài khoản giáo viên để giao bài kiểm tra và theo dõi sự tiến bộ của học sinh.',
+        'Tích hợp hội thảo trực tuyến hoặc video thí nghiệm đã ghi hình.'
+      ]
+    },
+    contactPage: {
+      eyebrow: 'Liên hệ',
+      heading: 'Kết nối với đội ngũ SciBridge',
+      formTitle: 'Gửi tin nhắn cho chúng tôi',
+      formDescription:
+        'Chia sẻ phản hồi, yêu cầu ý tưởng bài học hoặc cho chúng tôi biết bạn sử dụng SciBridge trong lớp học như thế nào.',
+      nameLabel: 'Họ và tên',
+      namePlaceholder: 'Tên đầy đủ của bạn',
+      emailLabel: 'Email',
+      emailPlaceholder: 'ban@vidu.com',
+      messageLabel: 'Tin nhắn',
+      messagePlaceholder: 'Chúng tôi có thể hỗ trợ gì?',
+      submit: 'Gửi tin nhắn',
+      quickInfoTitle: 'Thông tin nhanh',
+      officeHours: 'Giờ làm việc',
+      community: 'Cộng đồng',
+      communityText: 'Tham gia diễn đàn giáo viên SciBridge để chia sẻ ý tưởng và kinh nghiệm hay.'
+    },
+    forumPage: {
+      title: 'Diễn đàn SciBridge',
+      description:
+        'Chia sẻ ý tưởng khoa học bằng tiếng Anh, đặt câu hỏi cho bạn học và cùng luyện từ vựng học thuật. Tạo tài khoản, xác minh email và đăng nhập để tham gia thảo luận.',
+      register: 'Đăng ký',
+      verify: 'Xác minh email',
+      login: 'Đăng nhập',
+      createAccount: 'Tạo tài khoản SciBridge',
+      fullName: 'Họ và tên',
+      namePlaceholder: 'Ví dụ: Lan – yêu Vật lý',
+      password: 'Mật khẩu',
+      passwordPlaceholder: 'Ít nhất 8 ký tự',
+      registerCta: 'Đăng ký và gửi mã',
+      sendingCode: 'Đang gửi mã xác minh…',
+      verificationTitle: 'Xác minh địa chỉ email',
+      verificationCode: 'Mã xác minh',
+      codePlaceholder: 'Nhập 6 ký tự',
+      confirmEmail: 'Xác nhận email',
+      checkingCode: 'Đang kiểm tra mã…',
+      welcomeBack: 'Chào mừng trở lại! Đăng nhập để đăng bài.',
+      loginPasswordPlaceholder: 'Nhập mật khẩu của bạn',
+      loggingIn: 'Đang đăng nhập…',
+      signedInAs: 'Đang đăng nhập với',
+      signOut: 'Đăng xuất',
+      needAnotherEmail:
+        'Cần email khác? Gửi lại biểu mẫu đăng ký để nhận mã mới. Email xác minh được gửi bằng SMTP để giáo viên kết nối hệ thống thư của lớp.',
+      startDiscussion: 'Bắt đầu thảo luận',
+      startDiscussionDescription:
+        'Chọn môn khoa học, viết trạng thái ngắn và giúp bạn học luyện tiếng Anh học thuật.',
+      subjectLabel: 'Môn học trọng tâm',
+      shareIdea: 'Chia sẻ ý tưởng',
+      sharePlaceholder: 'Giải thích khái niệm, đặt câu hỏi hoặc chia sẻ mẹo học tập.',
+      postStatus: 'Đăng trạng thái',
+      addComment: 'Thêm bình luận',
+      commentPlaceholder: 'Góp ý bằng ngôn ngữ khoa học thân thiện.',
+      reply: 'Trả lời',
+      forumTips: 'Gợi ý tham gia diễn đàn',
+      tipFramesLabel: 'Dùng mẫu câu tiếng Anh:',
+      tipFrames: '“I wonder if…”, “In my experiment…”, “I predict that…”.',
+      tipRespectLabel: 'Tôn trọng bạn học:',
+      tipRespect: 'Trân trọng ý tưởng mới và đặt câu hỏi tích cực. Giữ bài viết thân thiện và học thuật.',
+      tipCiteLabel: 'Dẫn nguồn:',
+      tipCite: 'Liên kết tới bài học, bài kiểm tra SciBridge hoặc nguồn bên ngoài.',
+      tipSafetyLabel: 'Giữ an toàn:',
+      tipSafety: 'Không chia sẻ mật khẩu riêng. Việc xác minh email giúp giới hạn diễn đàn cho học viên được mời.',
+      pleaseLogin: 'Vui lòng đăng nhập trước khi đăng bài.',
+      enterIdea: 'Hãy viết ý tưởng hoặc câu hỏi trước khi chia sẻ.',
+      statusShared: 'Cập nhật của bạn đã được chia sẻ với cộng đồng!',
+      loginToComment: 'Vui lòng đăng nhập để tham gia thảo luận.',
+      addHelpfulComment: 'Thêm bình luận hữu ích trước khi gửi.',
+      thankForComment: 'Cảm ơn bạn đã đóng góp cho cuộc trò chuyện!',
+      readyToPost: 'Bạn đã đăng nhập và sẵn sàng đăng bài!',
+      signedOut: 'Đăng xuất',
+      verificationNotice:
+        'Chúng tôi gửi mã xác minh qua email bằng dịch vụ SMTP bảo mật. Nhập mã để kích hoạt tài khoản trước khi đăng bài.',
+      email: 'Email',
+      subjects: {
+        'English for Science': 'Tiếng Anh cho Khoa học',
+        Physics: 'Vật lý',
+        Chemistry: 'Hóa học',
+        Biology: 'Sinh học',
+        'Earth Science': 'Khoa học Trái Đất'
+      },
+      posts: {
+        post1: {
+          author: 'Maya (Nhà khám phá Vật lý)',
+          content:
+            'Mình dùng mô phỏng vận tốc trong bài học Vật lý để luyện các từ chỉ hướng bằng tiếng Anh. Hãy thử mô tả chuyển động bằng hướng bắc, nam, đông, tây nhé!',
+          comments: {
+            comment1: {
+              author: 'Leo',
+              content: 'Cảm ơn Maya! Mình sẽ vẽ thêm mũi tên trong sổ khoa học để giải thích hướng.'
+            }
+          }
+        },
+        post2: {
+          author: 'Sara (Nhà sinh học tương lai)',
+          content:
+            'Có ai có mẹo ghi nhớ các bước quang hợp bằng tiếng Anh không? Mình đã tạo một bài hát với “ánh sáng, nước và khí CO₂” làm điệp khúc.',
+          comments: {
+            comment2: {
+              author: 'Aisha',
+              content: 'Mình thích vẽ sơ đồ có nhãn: ánh sáng → lá → đường. Có thể chúng ta cùng chia sẻ bài hát nhé?'
+            },
+            comment3: {
+              author: 'Diego',
+              content: 'Cô giáo bảo mình nhớ “cây dùng ánh sáng để nấu đường”. Đơn giản mà hiệu quả!'
+            }
+          }
+        },
+        post3: {
+          author: 'Cô Lopez (Huấn luyện viên tiếng Anh)',
+          content:
+            'Bạn giải thích quy tắc an toàn phòng thí nghiệm bằng tiếng Anh như thế nào? Hãy chia sẻ những động từ bạn dùng khi hướng dẫn như “đeo”, “đo” và “ghi chép”.',
+          comments: {
+            comment4: {
+              author: 'Omar',
+              content:
+                'Mình bắt đầu câu bằng động từ hành động: Đeo kính bảo hộ. Đo dung dịch cẩn thận. Ghi chép kết quả của bạn.'
+            }
+          }
+        }
+      }
+    },
+    adminPage: {
+      accessDeniedTitle: 'Cần quyền giáo viên hoặc quản trị để truy cập bảng điều khiển.',
+      loading: 'Đang tải dữ liệu bảng điều khiển…',
+      error: 'Không thể tải bảng điều khiển: {message}',
+      announcementTitle: 'Thông báo mới',
+      announcementAudience: 'Đối tượng',
+      announcementMessage: 'Nội dung',
+      announcementPublish: 'Đăng thông báo',
+      contestTitle: 'Cuộc thi mới',
+      contestDescription: 'Mô tả',
+      contestDeadline: 'Hạn chót',
+      contestCreate: 'Tạo cuộc thi',
+      practiceTitle: 'Bộ luyện tập',
+      practiceFocus: 'Chủ điểm',
+      practiceResource: 'Liên kết tài nguyên',
+      practiceShare: 'Chia sẻ bộ luyện tập',
+      usersHeading: 'Quản lý người dùng',
+      updateUser: 'Cập nhật',
+      suspendUser: 'Tạm dừng',
+      activateUser: 'Kích hoạt',
+      approvalsHeading: 'Yêu cầu phê duyệt',
+      contestsHeading: 'Cuộc thi hiện có',
+      practiceSetsHeading: 'Bộ luyện tập đã chia sẻ',
+      announcementsHeading: 'Thông báo đã đăng'
+    },
+    notFound: {
+      title: 'Không tìm thấy trang',
+      description: 'Đường dẫn bạn truy cập không tồn tại. Hãy quay lại trang chủ để tiếp tục học.',
+      backHome: 'Về trang chủ'
+    }
+  }
+};
+

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,11 +3,14 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App.jsx';
 import './index.css';
+import { LanguageProvider } from './context/LanguageContext.jsx';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <LanguageProvider>
+        <App />
+      </LanguageProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/pages/AboutPage.jsx
+++ b/src/pages/AboutPage.jsx
@@ -1,28 +1,39 @@
+import { useLanguage } from '../context/LanguageContext.jsx';
+
 const AboutPage = () => {
+  const { t } = useLanguage();
+  const expandList = t('aboutPage.expandList', [
+    'Add more lessons with local examples and culturally relevant case studies.',
+    'Translate key vocabulary into other languages for multilingual classrooms.',
+    'Create teacher accounts to assign quizzes and track student growth.',
+    'Integrate live webinars or recorded lab demonstrations.'
+  ]);
   return (
     <div className="mx-auto max-w-4xl space-y-8 px-4 py-10">
       <header className="space-y-3">
-        <p className="text-xs font-semibold uppercase tracking-wide text-brand-dark">About</p>
-        <h1 className="text-3xl font-display font-semibold text-slate-900">Our mission</h1>
+        <p className="text-xs font-semibold uppercase tracking-wide text-brand-dark">
+          {t('aboutPage.eyebrow', 'About')}
+        </p>
+        <h1 className="text-3xl font-display font-semibold text-slate-900">{t('aboutPage.heading', 'Our mission')}</h1>
       </header>
       <section className="space-y-4 rounded-3xl bg-white p-6 shadow">
-        <p className="text-sm leading-7 text-slate-700">
-          SciBridge supports high school students who study Natural Sciences in English. We combine accurate science content with
-          friendly explanations, vocabulary supports, and multimedia to build confidence. Each lesson is written with simple
-          academic language so English learners can participate fully in science classes.
-        </p>
-        <p className="text-sm leading-7 text-slate-700">
-          Our teaching team includes science educators, language specialists, and designers. Together we create flexible learning
-          modules that teachers can use in class or students can explore independently.
-        </p>
+        <p className="text-sm leading-7 text-slate-700">{t(
+          'aboutPage.description1',
+          'SciBridge supports high school students who study Natural Sciences in English. We combine accurate science content with friendly explanations, vocabulary supports, and multimedia to build confidence. Each lesson is written with simple academic language so English learners can participate fully in science classes.'
+        )}</p>
+        <p className="text-sm leading-7 text-slate-700">{t(
+          'aboutPage.description2',
+          'Our teaching team includes science educators, language specialists, and designers. Together we create flexible learning modules that teachers can use in class or students can explore independently.'
+        )}</p>
       </section>
       <section className="space-y-4 rounded-3xl border border-brand/30 bg-brand-light/60 p-6">
-        <h2 className="text-xl font-display font-semibold text-brand-dark">How to expand this site</h2>
+        <h2 className="text-xl font-display font-semibold text-brand-dark">
+          {t('aboutPage.expandHeading', 'How to expand this site')}
+        </h2>
         <ul className="list-disc space-y-2 pl-6 text-sm text-slate-700">
-          <li>Add more lessons with local examples and culturally relevant case studies.</li>
-          <li>Translate key vocabulary into other languages for multilingual classrooms.</li>
-          <li>Create teacher accounts to assign quizzes and track student growth.</li>
-          <li>Integrate live webinars or recorded lab demonstrations.</li>
+          {expandList.map((item, index) => (
+            <li key={index}>{item}</li>
+          ))}
         </ul>
       </section>
     </div>

--- a/src/pages/ContactPage.jsx
+++ b/src/pages/ContactPage.jsx
@@ -1,51 +1,61 @@
+import { useLanguage } from '../context/LanguageContext.jsx';
+
 const ContactPage = () => {
+  const { t } = useLanguage();
   return (
     <div className="mx-auto max-w-4xl space-y-8 px-4 py-10">
       <header className="space-y-3">
-        <p className="text-xs font-semibold uppercase tracking-wide text-brand-dark">Contact</p>
-        <h1 className="text-3xl font-display font-semibold text-slate-900">Connect with the SciBridge team</h1>
+        <p className="text-xs font-semibold uppercase tracking-wide text-brand-dark">
+          {t('contactPage.eyebrow', 'Contact')}
+        </p>
+        <h1 className="text-3xl font-display font-semibold text-slate-900">
+          {t('contactPage.heading', 'Connect with the SciBridge team')}
+        </h1>
       </header>
       <section className="grid gap-6 md:grid-cols-2">
         <div className="space-y-4 rounded-3xl bg-white p-6 shadow">
-          <h2 className="text-xl font-semibold text-slate-900">Send us a message</h2>
+          <h2 className="text-xl font-semibold text-slate-900">{t('contactPage.formTitle', 'Send us a message')}</h2>
           <p className="text-sm text-slate-600">
-            Share feedback, ask for lesson ideas, or tell us how you use SciBridge in your classroom.
+            {t(
+              'contactPage.formDescription',
+              'Share feedback, ask for lesson ideas, or tell us how you use SciBridge in your classroom.'
+            )}
           </p>
           <form className="space-y-4">
             <label className="block text-sm">
-              <span className="text-slate-600">Name</span>
+              <span className="text-slate-600">{t('contactPage.nameLabel', 'Name')}</span>
               <input
                 type="text"
                 className="mt-1 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-2 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30"
-                placeholder="Your full name"
+                placeholder={t('contactPage.namePlaceholder', 'Your full name')}
               />
             </label>
             <label className="block text-sm">
-              <span className="text-slate-600">Email</span>
+              <span className="text-slate-600">{t('contactPage.emailLabel', 'Email')}</span>
               <input
                 type="email"
                 className="mt-1 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-2 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30"
-                placeholder="you@example.com"
+                placeholder={t('contactPage.emailPlaceholder', 'you@example.com')}
               />
             </label>
             <label className="block text-sm">
-              <span className="text-slate-600">Message</span>
+              <span className="text-slate-600">{t('contactPage.messageLabel', 'Message')}</span>
               <textarea
                 rows="4"
                 className="mt-1 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-2 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30"
-                placeholder="How can we help?"
+                placeholder={t('contactPage.messagePlaceholder', 'How can we help?')}
               />
             </label>
             <button
               type="button"
               className="w-full rounded-full bg-brand px-4 py-3 text-sm font-semibold text-white shadow hover:bg-brand-dark"
             >
-              Send message
+              {t('contactPage.submit', 'Send message')}
             </button>
           </form>
         </div>
         <div className="space-y-4 rounded-3xl border border-brand/30 bg-brand-light/60 p-6">
-          <h2 className="text-xl font-semibold text-brand-dark">Quick information</h2>
+          <h2 className="text-xl font-semibold text-brand-dark">{t('contactPage.quickInfoTitle', 'Quick information')}</h2>
           <div className="space-y-3 text-sm text-slate-700">
             <p>
               <strong>Email:</strong> hello@scibridge.edu
@@ -54,10 +64,13 @@ const ContactPage = () => {
               <strong>Phone:</strong> +1 (555) 123-4567
             </p>
             <p>
-              <strong>Office hours:</strong> Monday – Friday, 09:00 – 17:00 (GMT)
+              <strong>{t('contactPage.officeHours', 'Office hours')}:</strong> Monday – Friday, 09:00 – 17:00 (GMT)
             </p>
             <p>
-              <strong>Community:</strong> Join the SciBridge teachers forum to share ideas and best practices.
+              <strong>{t('contactPage.community', 'Community')}:</strong> {t(
+                'contactPage.communityText',
+                'Join the SciBridge teachers forum to share ideas and best practices.'
+              )}
             </p>
           </div>
         </div>

--- a/src/pages/ForumPage.jsx
+++ b/src/pages/ForumPage.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
   FiAlertCircle,
@@ -11,10 +11,12 @@ import {
   FiUser
 } from 'react-icons/fi';
 import { registerUser, verifyEmail, loginUser } from '../services/authService';
+import { useLanguage } from '../context/LanguageContext.jsx';
 
 const initialPosts = [
   {
     id: 'post-1',
+    translationId: 'post1',
     author: 'Maya (Physics Explorer)',
     subject: 'Physics',
     createdAt: '2024-04-14T10:15:00Z',
@@ -23,6 +25,7 @@ const initialPosts = [
     comments: [
       {
         id: 'comment-1',
+        translationId: 'comment1',
         author: 'Leo',
         createdAt: '2024-04-14T12:05:00Z',
         content: 'Thanks Maya! I will add arrows to my science notebook to explain directions.'
@@ -31,6 +34,7 @@ const initialPosts = [
   },
   {
     id: 'post-2',
+    translationId: 'post2',
     author: 'Sara (Future Biologist)',
     subject: 'Biology',
     createdAt: '2024-04-13T08:45:00Z',
@@ -39,22 +43,23 @@ const initialPosts = [
     comments: [
       {
         id: 'comment-2',
+        translationId: 'comment2',
         author: 'Aisha',
         createdAt: '2024-04-13T09:10:00Z',
         content: 'I like to make a diagram with labels: sunlight → leaves → glucose. Maybe we can share our songs?'
       },
       {
         id: 'comment-3',
+        translationId: 'comment3',
         author: 'Diego',
         createdAt: '2024-04-13T10:02:00Z',
         content: 'My teacher says to remember “plants use light to cook sugar.” Simple but it helps!'
       }
     ]
-  }
-];
-
+  },
   {
     id: 'post-3',
+    translationId: 'post3',
     author: 'Ms. Lopez (English Coach)',
     subject: 'English for Science',
     createdAt: '2024-04-12T15:30:00Z',
@@ -63,6 +68,7 @@ const initialPosts = [
     comments: [
       {
         id: 'comment-4',
+        translationId: 'comment4',
         author: 'Omar',
         createdAt: '2024-04-12T16:00:00Z',
         content: 'I start sentences with action verbs: Wear goggles. Measure the liquid carefully. Record your results.'
@@ -79,24 +85,21 @@ const subjectAccent = {
   'English for Science': 'bg-brand-light text-brand-dark'
 };
 
-const formatDate = (isoDate) =>
-  new Intl.DateTimeFormat('en', {
+const formatDate = (isoDate, locale = 'en') =>
+  new Intl.DateTimeFormat(locale, {
     dateStyle: 'medium',
     timeStyle: 'short'
   }).format(new Date(isoDate));
 
-const authTabs = [
-  { key: 'register', label: 'Register' },
-  { key: 'verify', label: 'Verify email' },
-  { key: 'login', label: 'Log in' }
-];
-
 const ForumPage = ({ user, onAuthSuccess, onLogout }) => {
+  const { t, language } = useLanguage();
+  const locale = language === 'vi' ? 'vi' : 'en';
+
   const [posts, setPosts] = useState(initialPosts);
   const [subject, setSubject] = useState('English for Science');
   const [statusText, setStatusText] = useState('');
   const [commentDrafts, setCommentDrafts] = useState({});
-  const [forumMessage, setForumMessage] = useState('');
+  const [forumMessage, setForumMessage] = useState(null);
 
   const [authView, setAuthView] = useState('register');
   const [registerForm, setRegisterForm] = useState({ name: '', email: '', password: '' });
@@ -110,19 +113,38 @@ const ForumPage = ({ user, onAuthSuccess, onLogout }) => {
     []
   );
 
+  const authTabs = useMemo(
+    () => [
+      { key: 'register', label: t('forumPage.register', 'Register') },
+      { key: 'verify', label: t('forumPage.verify', 'Verify email') },
+      { key: 'login', label: t('forumPage.login', 'Log in') }
+    ],
+    [t]
+  );
+
+  const translateSubject = useCallback(
+    (value) => t(['forumPage', 'subjects', value], value),
+    [t]
+  );
+
+  const showForumMessage = (key, fallback) => {
+    setForumMessage({ key, fallback });
+  };
+
   const handleStatusSubmit = (event) => {
     event.preventDefault();
     if (!user) {
-      setForumMessage('Please log in before posting to the forum.');
+      showForumMessage('forumPage.pleaseLogin', 'Please log in before posting to the forum.');
       return;
     }
     if (!statusText.trim()) {
-      setForumMessage('Write a short idea or question before sharing.');
+      showForumMessage('forumPage.enterIdea', 'Write a short idea or question before sharing.');
       return;
     }
 
     const newPost = {
       id: `post-${Date.now()}`,
+      translationId: null,
       author: `${user.name} (${user.email})`,
       subject,
       createdAt: new Date().toISOString(),
@@ -132,23 +154,30 @@ const ForumPage = ({ user, onAuthSuccess, onLogout }) => {
 
     setPosts((previous) => [newPost, ...previous]);
     setStatusText('');
-    setForumMessage('Your update has been shared with the community!');
+    showForumMessage(
+      'forumPage.statusShared',
+      'Your update has been shared with the community!'
+    );
   };
 
   const handleCommentSubmit = (postId) => {
     if (!user) {
-      setForumMessage('Please log in to join the discussion.');
+      showForumMessage('forumPage.loginToComment', 'Please log in to join the discussion.');
       return;
     }
 
     const draft = commentDrafts[postId]?.trim();
     if (!draft) {
-      setForumMessage('Add a helpful comment before submitting.');
+      showForumMessage(
+        'forumPage.addHelpfulComment',
+        'Add a helpful comment before submitting.'
+      );
       return;
     }
 
     const newComment = {
       id: `comment-${Date.now()}`,
+      translationId: null,
       author: `${user.name} (${user.email})`,
       createdAt: new Date().toISOString(),
       content: draft
@@ -163,12 +192,12 @@ const ForumPage = ({ user, onAuthSuccess, onLogout }) => {
     );
 
     setCommentDrafts((previous) => ({ ...previous, [postId]: '' }));
-    setForumMessage('Thank you for adding to the conversation!');
+    showForumMessage('forumPage.thankForComment', 'Thank you for adding to the conversation!');
   };
 
   const resetMessages = () => {
     setAuthMessage(null);
-    setForumMessage('');
+    setForumMessage(null);
   };
 
   const handleRegister = async (event) => {
@@ -216,7 +245,7 @@ const ForumPage = ({ user, onAuthSuccess, onLogout }) => {
       setAuthMessage({ type: 'success', text: message });
       setLoginForm((previous) => ({ ...previous, password: '' }));
       onAuthSuccess?.(profile);
-      setForumMessage('You are signed in and ready to post!');
+      showForumMessage('forumPage.readyToPost', 'You are signed in and ready to post!');
     } catch (error) {
       setAuthMessage({ type: 'error', text: error.message });
     } finally {
@@ -250,7 +279,7 @@ const ForumPage = ({ user, onAuthSuccess, onLogout }) => {
     return (
       <div className="flex items-center gap-2 rounded-lg border border-brand-light bg-brand-light/40 px-3 py-2 text-sm font-semibold text-brand-dark">
         <FiMessageCircle aria-hidden />
-        <span>{forumMessage}</span>
+        <span>{t(forumMessage.key, forumMessage.fallback)}</span>
       </div>
     );
   };
@@ -259,9 +288,12 @@ const ForumPage = ({ user, onAuthSuccess, onLogout }) => {
     <section className="bg-gradient-to-b from-slate-50 to-white py-12">
       <div className="mx-auto flex max-w-6xl flex-col gap-10 px-4">
         <header className="rounded-3xl bg-brand-light/60 p-8 shadow-sm">
-          <h1 className="font-display text-3xl font-bold text-brand-dark">SciBridge Forum</h1>
+          <h1 className="font-display text-3xl font-bold text-brand-dark">{t('forumPage.title', 'SciBridge Forum')}</h1>
           <p className="mt-4 max-w-3xl text-base text-slate-600">
-            Share science ideas in English, ask classmates questions, and practice academic vocabulary together. Create an account, verify your email address, and log in to join the conversation.
+            {t(
+              'forumPage.description',
+              'Share science ideas in English, ask classmates questions, and practice academic vocabulary together. Create an account, verify your email address, and log in to join the conversation.'
+            )}
           </p>
           {!user ? (
             <div className="mt-6 rounded-2xl bg-white p-6 shadow-inner">
@@ -289,10 +321,10 @@ const ForumPage = ({ user, onAuthSuccess, onLogout }) => {
                 <form onSubmit={handleRegister} className="mt-4 grid gap-4 sm:grid-cols-2">
                   <div className="sm:col-span-2 flex items-center gap-2 text-sm font-semibold text-brand-dark">
                     <FiUser aria-hidden />
-                    Create your SciBridge account
+                    {t('forumPage.createAccount', 'Create your SciBridge account')}
                   </div>
                   <label className="flex flex-col text-sm font-semibold text-slate-600">
-                    Full name
+                    {t('forumPage.fullName', 'Full name')}
                     <input
                       type="text"
                       value={registerForm.name}
@@ -300,12 +332,12 @@ const ForumPage = ({ user, onAuthSuccess, onLogout }) => {
                         setRegisterForm((previous) => ({ ...previous, name: event.target.value }))
                       }
                       className="mt-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30"
-                      placeholder="e.g., Jamie the Chemist"
+                      placeholder={t('forumPage.namePlaceholder', 'e.g., Jamie the Chemist')}
                       required
                     />
                   </label>
                   <label className="flex flex-col text-sm font-semibold text-slate-600">
-                    Email
+                    {t('forumPage.email', 'Email')}
                     <input
                       type="email"
                       value={registerForm.email}
@@ -318,7 +350,7 @@ const ForumPage = ({ user, onAuthSuccess, onLogout }) => {
                     />
                   </label>
                   <label className="flex flex-col text-sm font-semibold text-slate-600">
-                    Password
+                    {t('forumPage.password', 'Password')}
                     <input
                       type="password"
                       value={registerForm.password}
@@ -326,13 +358,16 @@ const ForumPage = ({ user, onAuthSuccess, onLogout }) => {
                         setRegisterForm((previous) => ({ ...previous, password: event.target.value }))
                       }
                       className="mt-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30"
-                      placeholder="Use at least 8 characters"
+                      placeholder={t('forumPage.passwordPlaceholder', 'Use at least 8 characters')}
                       required
                       minLength={8}
                     />
                   </label>
                   <p className="sm:col-span-2 text-xs text-slate-500">
-                    We send a verification code to your email using secure SMTP delivery. Enter the code to activate your account before you post.
+                    {t(
+                      'forumPage.verificationNotice',
+                      'We send a verification code to your email using secure SMTP delivery. Enter the code to activate your account before you post.'
+                    )}
                   </p>
                   <button
                     type="submit"
@@ -340,7 +375,9 @@ const ForumPage = ({ user, onAuthSuccess, onLogout }) => {
                     disabled={isSubmitting}
                   >
                     <FiMail aria-hidden />
-                    {isSubmitting ? 'Sending verification email…' : 'Register and send code'}
+                    {isSubmitting
+                      ? t('forumPage.sendingCode', 'Sending verification email…')
+                      : t('forumPage.registerCta', 'Register and send code')}
                   </button>
                 </form>
               )}
@@ -348,10 +385,10 @@ const ForumPage = ({ user, onAuthSuccess, onLogout }) => {
                 <form onSubmit={handleVerify} className="mt-4 grid gap-4 sm:grid-cols-2">
                   <div className="sm:col-span-2 flex items-center gap-2 text-sm font-semibold text-brand-dark">
                     <FiMail aria-hidden />
-                    Verify your email address
+                    {t('forumPage.verificationTitle', 'Verify your email address')}
                   </div>
                   <label className="flex flex-col text-sm font-semibold text-slate-600">
-                    Email
+                    {t('forumPage.email', 'Email')}
                     <input
                       type="email"
                       value={verifyForm.email}
@@ -364,7 +401,7 @@ const ForumPage = ({ user, onAuthSuccess, onLogout }) => {
                     />
                   </label>
                   <label className="flex flex-col text-sm font-semibold text-slate-600">
-                    Verification code
+                    {t('forumPage.verificationCode', 'Verification code')}
                     <input
                       type="text"
                       value={verifyForm.code}
@@ -372,7 +409,7 @@ const ForumPage = ({ user, onAuthSuccess, onLogout }) => {
                         setVerifyForm((previous) => ({ ...previous, code: event.target.value.toUpperCase() }))
                       }
                       className="mt-2 uppercase tracking-widest rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30"
-                      placeholder="Enter 6 letters"
+                      placeholder={t('forumPage.codePlaceholder', 'Enter 6 letters')}
                       required
                       minLength={6}
                       maxLength={6}
@@ -384,7 +421,9 @@ const ForumPage = ({ user, onAuthSuccess, onLogout }) => {
                     disabled={isSubmitting}
                   >
                     <FiCheckCircle aria-hidden />
-                    {isSubmitting ? 'Checking code…' : 'Confirm email'}
+                    {isSubmitting
+                      ? t('forumPage.checkingCode', 'Checking code…')
+                      : t('forumPage.confirmEmail', 'Confirm email')}
                   </button>
                 </form>
               )}
@@ -392,10 +431,10 @@ const ForumPage = ({ user, onAuthSuccess, onLogout }) => {
                 <form onSubmit={handleLogin} className="mt-4 grid gap-4 sm:grid-cols-2">
                   <div className="sm:col-span-2 flex items-center gap-2 text-sm font-semibold text-brand-dark">
                     <FiLogIn aria-hidden />
-                    Welcome back! Log in to post.
+                    {t('forumPage.welcomeBack', 'Welcome back! Log in to post.')}
                   </div>
                   <label className="flex flex-col text-sm font-semibold text-slate-600">
-                    Email
+                    {t('forumPage.email', 'Email')}
                     <input
                       type="email"
                       value={loginForm.email}
@@ -408,7 +447,7 @@ const ForumPage = ({ user, onAuthSuccess, onLogout }) => {
                     />
                   </label>
                   <label className="flex flex-col text-sm font-semibold text-slate-600">
-                    Password
+                    {t('forumPage.password', 'Password')}
                     <input
                       type="password"
                       value={loginForm.password}
@@ -416,7 +455,7 @@ const ForumPage = ({ user, onAuthSuccess, onLogout }) => {
                         setLoginForm((previous) => ({ ...previous, password: event.target.value }))
                       }
                       className="mt-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30"
-                      placeholder="Enter your password"
+                      placeholder={t('forumPage.loginPasswordPlaceholder', 'Enter your password')}
                       required
                     />
                   </label>
@@ -426,18 +465,23 @@ const ForumPage = ({ user, onAuthSuccess, onLogout }) => {
                     disabled={isSubmitting}
                   >
                     <FiLock aria-hidden />
-                    {isSubmitting ? 'Signing in…' : 'Log in'}
+                    {isSubmitting
+                      ? t('forumPage.loggingIn', 'Signing in…')
+                      : t('forumPage.login', 'Log in')}
                   </button>
                 </form>
               )}
               <p className="mt-6 text-xs text-slate-500">
-                Need another email? Submit the register form again to generate a new code. Verification emails are sent with SMTP so your teacher can connect the classroom mail provider.
+                {t(
+                  'forumPage.needAnotherEmail',
+                  'Need another email? Submit the register form again to generate a new code. Verification emails are sent with SMTP so your teacher can connect the classroom mail provider.'
+                )}
               </p>
             </div>
           ) : (
             <div className="mt-6 flex flex-col gap-3 rounded-2xl bg-white p-6 shadow-inner sm:flex-row sm:items-center sm:justify-between">
               <div>
-                <p className="text-sm font-semibold text-slate-600">Signed in as</p>
+                <p className="text-sm font-semibold text-slate-600">{t('forumPage.signedInAs', 'Signed in as')}</p>
                 <p className="text-lg font-display font-semibold text-brand-dark">{user.name}</p>
                 <p className="text-sm text-slate-500">{user.email}</p>
                 <p className="mt-1 inline-flex items-center gap-2 rounded-full bg-brand-light/50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-brand-dark">
@@ -450,12 +494,12 @@ const ForumPage = ({ user, onAuthSuccess, onLogout }) => {
                   onLogout?.();
                   setAuthView('login');
                   setAuthMessage(null);
-                  setForumMessage('');
+                  setForumMessage(null);
                 }}
                 className="inline-flex items-center justify-center gap-2 rounded-lg bg-brand px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-dark"
               >
                 <FiLogIn aria-hidden />
-                Sign out
+                {t('forumPage.signOut', 'Sign out')}
               </button>
             </div>
           )}
@@ -465,31 +509,39 @@ const ForumPage = ({ user, onAuthSuccess, onLogout }) => {
 
         <section className="grid gap-8 lg:grid-cols-[1.2fr_0.8fr]">
           <article className="rounded-3xl bg-white p-8 shadow-sm">
-            <h2 className="font-display text-2xl font-semibold text-brand-dark">Start a discussion</h2>
+            <h2 className="font-display text-2xl font-semibold text-brand-dark">{t('forumPage.startDiscussion', 'Start a discussion')}</h2>
             <p className="mt-2 text-sm text-slate-500">
-              Choose a science subject, write a short status, and help your classmates practice English academic language.
+              {t(
+                'forumPage.startDiscussionDescription',
+                'Choose a science subject, write a short status, and help your classmates practice English academic language.'
+              )}
             </p>
             <form onSubmit={handleStatusSubmit} className="mt-6 space-y-4">
               <label className="flex flex-col text-sm font-semibold text-slate-600">
-                Subject focus
+                {t('forumPage.subjectLabel', 'Subject focus')}
                 <select
                   value={subject}
                   onChange={(event) => setSubject(event.target.value)}
                   className="mt-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30"
                 >
                   {activeSubjects.map((subjectName) => (
-                    <option key={subjectName}>{subjectName}</option>
+                    <option key={subjectName} value={subjectName}>
+                      {translateSubject(subjectName)}
+                    </option>
                   ))}
                 </select>
               </label>
               <label className="flex flex-col text-sm font-semibold text-slate-600">
-                Share your idea
+                {t('forumPage.shareIdea', 'Share your idea')}
                 <textarea
                   value={statusText}
                   onChange={(event) => setStatusText(event.target.value)}
                   rows={4}
                   className="mt-2 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30"
-                  placeholder="Explain a concept, ask a question, or share a study tip."
+                  placeholder={t(
+                    'forumPage.sharePlaceholder',
+                    'Explain a concept, ask a question, or share a study tip.'
+                  )}
                 />
               </label>
               <button
@@ -497,79 +549,122 @@ const ForumPage = ({ user, onAuthSuccess, onLogout }) => {
                 className="inline-flex items-center justify-center gap-2 rounded-full bg-brand px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-dark"
               >
                 <FiSend aria-hidden />
-                Post status
+                {t('forumPage.postStatus', 'Post status')}
               </button>
             </form>
             <div className="mt-8 space-y-6">
-              {posts.map((post) => (
-                <article key={post.id} className="rounded-2xl border border-slate-100 bg-slate-50/60 p-6 shadow-inner">
-                  <div className="flex flex-wrap items-center justify-between gap-3">
-                    <div>
-                      <p className="text-base font-semibold text-brand-dark">{post.author}</p>
-                      <p className="text-xs uppercase tracking-wide text-slate-400">{formatDate(post.createdAt)}</p>
-                    </div>
-                    <span className={`rounded-full px-3 py-1 text-xs font-semibold ${subjectAccent[post.subject]}`}>
-                      {post.subject}
-                    </span>
-                  </div>
-                  <p className="mt-4 text-sm text-slate-600">{post.content}</p>
-                  <div className="mt-6 space-y-4">
-                    {post.comments.map((comment) => (
-                      <div key={comment.id} className="rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-600">
-                        <div className="flex items-center justify-between">
-                          <span className="font-semibold text-brand-dark">{comment.author}</span>
-                          <span className="text-xs uppercase tracking-wide text-slate-400">{formatDate(comment.createdAt)}</span>
-                        </div>
-                        <p className="mt-2 text-sm text-slate-600">{comment.content}</p>
+              {posts.map((post) => {
+                const author = t(
+                  ['forumPage', 'posts', post.translationId ?? '', 'author'],
+                  post.author
+                );
+                const content = t(
+                  ['forumPage', 'posts', post.translationId ?? '', 'content'],
+                  post.content
+                );
+                return (
+                  <article key={post.id} className="rounded-2xl border border-slate-100 bg-slate-50/60 p-6 shadow-inner">
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div>
+                        <p className="text-base font-semibold text-brand-dark">{author}</p>
+                        <p className="text-xs uppercase tracking-wide text-slate-400">
+                          {formatDate(post.createdAt, locale)}
+                        </p>
                       </div>
-                    ))}
-                    <form
-                      onSubmit={(event) => {
-                        event.preventDefault();
-                        handleCommentSubmit(post.id);
-                      }}
-                      className="rounded-xl border border-slate-200 bg-white px-4 py-3"
-                    >
-                      <label className="flex flex-col text-xs font-semibold text-slate-500">
-                        Add a comment
-                        <textarea
-                          value={commentDrafts[post.id] ?? ''}
-                          onChange={(event) =>
-                            setCommentDrafts((previous) => ({ ...previous, [post.id]: event.target.value }))
-                          }
-                          rows={2}
-                          className="mt-2 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30"
-                          placeholder="Give feedback using friendly science vocabulary."
-                        />
-                      </label>
-                      <button
-                        type="submit"
-                        className="mt-3 inline-flex items-center gap-2 rounded-full bg-brand/90 px-4 py-2 text-xs font-semibold text-white transition hover:bg-brand-dark"
+                      <span className={`rounded-full px-3 py-1 text-xs font-semibold ${subjectAccent[post.subject]}`}>
+                        {translateSubject(post.subject)}
+                      </span>
+                    </div>
+                    <p className="mt-4 text-sm text-slate-600">{content}</p>
+                    <div className="mt-6 space-y-4">
+                      {post.comments.map((comment) => {
+                        const commentAuthor = t(
+                          ['forumPage', 'posts', post.translationId ?? '', 'comments', comment.translationId ?? '', 'author'],
+                          comment.author
+                        );
+                        const commentContent = t(
+                          ['forumPage', 'posts', post.translationId ?? '', 'comments', comment.translationId ?? '', 'content'],
+                          comment.content
+                        );
+                        return (
+                          <div key={comment.id} className="rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-600">
+                            <div className="flex items-center justify-between">
+                              <span className="font-semibold text-brand-dark">{commentAuthor}</span>
+                              <span className="text-xs uppercase tracking-wide text-slate-400">
+                                {formatDate(comment.createdAt, locale)}
+                              </span>
+                            </div>
+                            <p className="mt-2 text-sm text-slate-600">{commentContent}</p>
+                          </div>
+                        );
+                      })}
+                      <form
+                        onSubmit={(event) => {
+                          event.preventDefault();
+                          handleCommentSubmit(post.id);
+                        }}
+                        className="rounded-xl border border-slate-200 bg-white px-4 py-3"
                       >
-                        <FiSend aria-hidden />
-                        Reply
-                      </button>
-                    </form>
-                  </div>
-                </article>
-              ))}
+                        <label className="flex flex-col text-xs font-semibold text-slate-500">
+                          {t('forumPage.addComment', 'Add a comment')}
+                          <textarea
+                            value={commentDrafts[post.id] ?? ''}
+                            onChange={(event) =>
+                              setCommentDrafts((previous) => ({ ...previous, [post.id]: event.target.value }))
+                            }
+                            rows={2}
+                            className="mt-2 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30"
+                            placeholder={t(
+                              'forumPage.commentPlaceholder',
+                              'Give feedback using friendly science vocabulary.'
+                            )}
+                          />
+                        </label>
+                        <button
+                          type="submit"
+                          className="mt-3 inline-flex items-center gap-2 rounded-full bg-brand/90 px-4 py-2 text-xs font-semibold text-white transition hover:bg-brand-dark"
+                        >
+                          <FiSend aria-hidden />
+                          {t('forumPage.reply', 'Reply')}
+                        </button>
+                      </form>
+                    </div>
+                  </article>
+                );
+              })}
             </div>
           </article>
 
           <aside className="rounded-3xl bg-white p-8 shadow-sm">
-            <h3 className="font-display text-xl font-semibold text-brand-dark">Forum tips</h3>
+            <h3 className="font-display text-xl font-semibold text-brand-dark">{t('forumPage.forumTips', 'Forum tips')}</h3>
             <ul className="mt-4 space-y-3 text-sm text-slate-600">
               <li className="rounded-xl bg-slate-50 p-3">
-                <span className="font-semibold text-brand-dark">Use English sentence frames:</span> “I wonder if…”, “In my experiment…”, “I predict that…”.
+                <span className="font-semibold text-brand-dark">
+                  {t('forumPage.tipFramesLabel', 'Use English sentence frames:')}
+                </span>{' '}
+                {t('forumPage.tipFrames', '“I wonder if…”, “In my experiment…”, “I predict that…”.')}
               </li>
               <li className="rounded-xl bg-slate-50 p-3">
-                <span className="font-semibold text-brand-dark">Respect classmates:</span> Celebrate new ideas and ask curious questions. Keep posts kind and academic.
+                <span className="font-semibold text-brand-dark">{t('forumPage.tipRespectLabel', 'Respect classmates:')}</span>{' '}
+                {t('forumPage.tipRespect', 'Celebrate new ideas and ask curious questions. Keep posts kind and academic.')}
               </li>
               <li className="rounded-xl bg-slate-50 p-3">
-                <span className="font-semibold text-brand-dark">Cite resources:</span> Link to SciBridge lessons, quizzes, or outside sources using <Link to="/resources" className="text-brand underline">Resources</Link>.
+                <span className="font-semibold text-brand-dark">{t('forumPage.tipCiteLabel', 'Cite resources:')}</span>{' '}
+                {t(
+                  'forumPage.tipCite',
+                  'Link to SciBridge lessons, quizzes, or outside sources using Resources.'
+                )}{' '}
+                <Link to="/resources" className="text-brand underline">
+                  {t('footer.resources', 'Resources')}
+                </Link>
+                .
               </li>
               <li className="rounded-xl bg-slate-50 p-3">
-                <span className="font-semibold text-brand-dark">Stay safe:</span> Never share private passwords. Email verification keeps the forum limited to invited learners.
+                <span className="font-semibold text-brand-dark">{t('forumPage.tipSafetyLabel', 'Stay safe:')}</span>{' '}
+                {t(
+                  'forumPage.tipSafety',
+                  'Never share private passwords. Email verification keeps the forum limited to invited learners.'
+                )}
               </li>
             </ul>
           </aside>
@@ -580,3 +675,4 @@ const ForumPage = ({ user, onAuthSuccess, onLogout }) => {
 };
 
 export default ForumPage;
+

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -7,9 +7,11 @@ import WordOfDay from '../components/WordOfDay';
 import ScienceChatbot from '../components/ScienceChatbot';
 import { subjects } from '../data/lessons';
 import { quizzes } from '../data/quizzes';
+import { useLanguage } from '../context/LanguageContext.jsx';
 
 const HomePage = () => {
   const featuredQuizzes = useMemo(() => quizzes.slice(0, 2), []);
+  const { t } = useLanguage();
 
   return (
     <div className="space-y-16">
@@ -17,14 +19,17 @@ const HomePage = () => {
       <section className="mx-auto max-w-6xl px-4">
         <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
           <div>
-            <p className="text-xs font-semibold uppercase tracking-wide text-brand-dark">Core and extension tracks</p>
+            <p className="text-xs font-semibold uppercase tracking-wide text-brand-dark">
+              {t('home.tracksEyebrow', 'Core and extension tracks')}
+            </p>
             <h2 className="mt-2 text-2xl font-display font-semibold text-slate-900">
-              Lead with English, then explore science extensions
+              {t('home.tracksHeading', 'Lead with English, then explore science extensions')}
             </h2>
             <p className="mt-2 max-w-2xl text-sm text-slate-600">
-              Begin with the English for Science track to practice vocabulary, grammar, and presentation phrases. When you feel
-              confident, continue to the extension modules for Physics, Chemistry, Biology, and Earth Science—each includes
-              visuals, videos, and key terms in learner-friendly English.
+              {t(
+                'home.tracksDescription',
+                'Begin with the English for Science track to practice vocabulary, grammar, and presentation phrases. When you feel confident, continue to the extension modules for Physics, Chemistry, Biology, and Earth Science—each includes visuals, videos, and key terms in learner-friendly English.'
+              )}
             </p>
           </div>
         </div>
@@ -36,7 +41,9 @@ const HomePage = () => {
       </section>
       <section className="mx-auto grid max-w-6xl gap-6 px-4 md:grid-cols-[2fr,1fr]">
         <div className="space-y-6">
-          <p className="text-xs font-semibold uppercase tracking-wide text-brand-dark">Interactive Practice</p>
+          <p className="text-xs font-semibold uppercase tracking-wide text-brand-dark">
+            {t('home.practiceEyebrow', 'Interactive Practice')}
+          </p>
           {featuredQuizzes.map((quiz) => (
             <QuizCard key={quiz.id} quiz={quiz} />
           ))}
@@ -48,16 +55,20 @@ const HomePage = () => {
       </section>
       <section className="mx-auto max-w-6xl px-4">
         <div className="rounded-3xl bg-brand-light/60 p-8 shadow-sm">
-          <h2 className="text-2xl font-display font-semibold text-brand-dark">Practice English with classmates</h2>
+          <h2 className="text-2xl font-display font-semibold text-brand-dark">
+            {t('home.forumHeading', 'Practice English with classmates')}
+          </h2>
           <p className="mt-3 max-w-3xl text-sm text-slate-600">
-            Join the SciBridge Forum to post study updates, ask questions in English, and support other students in Physics,
-            Chemistry, Biology, and Earth Science. Create an account, verify your email, and log in to share your voice safely.
+            {t(
+              'home.forumDescription',
+              'Join the SciBridge Forum to post study updates, ask questions in English, and support other students in Physics, Chemistry, Biology, and Earth Science. Create an account, verify your email, and log in to share your voice safely.'
+            )}
           </p>
           <Link
             to="/forum"
             className="mt-6 inline-flex items-center gap-2 rounded-full bg-brand px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-dark"
           >
-            Visit the forum
+            {t('home.forumCta', 'Visit the forum')}
           </Link>
         </div>
       </section>

--- a/src/pages/LessonPage.jsx
+++ b/src/pages/LessonPage.jsx
@@ -1,9 +1,11 @@
 import { useMemo } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { subjects } from '../data/lessons';
+import { useLanguage } from '../context/LanguageContext.jsx';
 
 const LessonPage = ({ onComplete, progress }) => {
   const { subjectId, lessonId } = useParams();
+  const { t } = useLanguage();
 
   const { subject, lesson } = useMemo(() => {
     const subjectData = subjects.find((item) => item.id === subjectId);
@@ -14,45 +16,61 @@ const LessonPage = ({ onComplete, progress }) => {
   if (!subject || !lesson) {
     return (
       <div className="mx-auto max-w-4xl px-4 py-20 text-center">
-        <h1 className="text-3xl font-display font-semibold text-slate-900">Lesson not found</h1>
+        <h1 className="text-3xl font-display font-semibold text-slate-900">
+          {t('lessonPage.notFoundTitle', 'Lesson not found')}
+        </h1>
         <Link to="/subjects" className="mt-6 inline-block rounded-full bg-brand px-6 py-3 text-sm font-semibold text-white">
-          Back to subjects
+          {t('lessonPage.backToSubjects', 'Back to subjects')}
         </Link>
       </div>
     );
   }
 
   const isCompleted = Boolean(progress[lesson.id]);
+  const subjectTitle = t(['subjects', subject.id, 'title'], subject.title);
+  const lessonTitle = t(['lessons', subject.id, lesson.id, 'title'], lesson.title);
+  const lessonSummary = t(['lessons', subject.id, lesson.id, 'summary'], lesson.summary);
+  const keyVocabulary = t(['lessons', subject.id, lesson.id, 'keyVocabulary'], lesson.keyVocabulary);
+  const lessonContent = t(['lessons', subject.id, lesson.id, 'content'], lesson.content);
+  const practiceIdeas = t(['lessons', subject.id, lesson.id, 'practice'], t('lessonPage.practiceList', [
+    'Write the key vocabulary words in your science notebook. Add a short definition in English.',
+    'Summarize the lesson in three sentences. Focus on the main idea and an example.',
+    'Teach a friend using the animation. Explain each step using the new words.'
+  ]));
 
   return (
     <article className="mx-auto max-w-4xl space-y-10 px-4 py-10">
       <nav className="text-sm text-slate-500">
         <Link to="/subjects" className="text-brand hover:text-brand-dark">
-          Subjects
+          {t('lessonPage.breadcrumbSubjects', 'Subjects')}
         </Link>{' '}
         /{' '}
         <Link to={`/subjects/${subject.id}`} className="text-brand hover:text-brand-dark">
-          {subject.title}
+          {subjectTitle}
         </Link>{' '}
-        / <span className="text-slate-700">{lesson.title}</span>
+        / <span className="text-slate-700">{lessonTitle}</span>
       </nav>
       <header className="space-y-4">
-        <p className="text-xs font-semibold uppercase tracking-wide text-brand-dark">Lesson</p>
-        <h1 className="text-3xl font-display font-semibold text-slate-900">{lesson.title}</h1>
-        <p className="text-base text-slate-600">{lesson.summary}</p>
+        <p className="text-xs font-semibold uppercase tracking-wide text-brand-dark">
+          {t('lessonPage.eyebrow', 'Lesson')}
+        </p>
+        <h1 className="text-3xl font-display font-semibold text-slate-900">{lessonTitle}</h1>
+        <p className="text-base text-slate-600">{lessonSummary}</p>
         <div className="flex flex-wrap gap-2 text-xs text-brand">
-          {lesson.keyVocabulary.map((word) => (
+          {keyVocabulary.map((word) => (
             <span key={word} className="rounded-full bg-brand-light/60 px-3 py-1 text-brand-dark">
               {word}
             </span>
           ))}
         </div>
       </header>
-      <img src={lesson.image} alt={lesson.title} className="w-full object-cover" />
+      <img src={lesson.image} alt={lessonTitle} className="w-full object-cover" />
       <section className="space-y-4">
-        <h2 className="text-xl font-display font-semibold text-slate-900">Step-by-step explanation</h2>
+        <h2 className="text-xl font-display font-semibold text-slate-900">
+          {t('lessonPage.stepsHeading', 'Step-by-step explanation')}
+        </h2>
         <div className="space-y-3 rounded-3xl bg-white p-6 shadow">
-          {lesson.content.map((paragraph, index) => (
+          {lessonContent.map((paragraph, index) => (
             <p key={index} className="text-sm leading-7 text-slate-700">
               {paragraph}
             </p>
@@ -61,14 +79,17 @@ const LessonPage = ({ onComplete, progress }) => {
       </section>
       <section className="grid gap-6 md:grid-cols-2">
         <div className="space-y-3 rounded-3xl bg-slate-900 p-6 text-white">
-          <h2 className="text-lg font-semibold">Watch the mini lesson</h2>
+          <h2 className="text-lg font-semibold">{t('lessonPage.videoHeading', 'Watch the mini lesson')}</h2>
           <p className="text-sm text-slate-100">
-            Videos help you connect English words with science visuals. Use captions to support language learning.
+            {t(
+              'lessonPage.videoDescription',
+              'Videos help you connect English words with science visuals. Use captions to support language learning.'
+            )}
           </p>
           <div className="aspect-video overflow-hidden rounded-2xl">
             <iframe
               src={lesson.videoUrl}
-              title={`${lesson.title} video`}
+              title={`${lessonTitle} video`}
               className="h-full w-full"
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
               allowFullScreen
@@ -76,9 +97,11 @@ const LessonPage = ({ onComplete, progress }) => {
           </div>
         </div>
         <div className="space-y-3 rounded-3xl border border-brand/30 bg-white p-6">
-          <h2 className="text-lg font-semibold text-slate-900">Animated concept</h2>
-          <p className="text-sm text-slate-600">Use the animation to observe the scientific process in motion.</p>
-          <img src={lesson.animationUrl} alt={`${lesson.title} animation`} className="h-64 w-full object-cover" />
+          <h2 className="text-lg font-semibold text-slate-900">{t('lessonPage.animationHeading', 'Animated concept')}</h2>
+          <p className="text-sm text-slate-600">
+            {t('lessonPage.animationDescription', 'Use the animation to observe the scientific process in motion.')}
+          </p>
+          <img src={lesson.animationUrl} alt={`${lessonTitle} animation`} className="h-64 w-full object-cover" />
           <button
             onClick={() => onComplete(lesson.id)}
             className={`w-full rounded-full px-4 py-3 text-sm font-semibold transition ${
@@ -87,16 +110,18 @@ const LessonPage = ({ onComplete, progress }) => {
                 : 'bg-brand text-white shadow hover:bg-brand-dark'
             }`}
           >
-            {isCompleted ? 'Lesson completed' : 'Mark lesson as completed'}
+            {isCompleted
+              ? t('lessonPage.completed', 'Lesson completed')
+              : t('lessonPage.markCompleted', 'Mark lesson as completed')}
           </button>
         </div>
       </section>
       <section className="rounded-3xl bg-brand-light/60 p-6">
-        <h2 className="text-lg font-semibold text-brand-dark">Practice ideas</h2>
+        <h2 className="text-lg font-semibold text-brand-dark">{t('lessonPage.practiceHeading', 'Practice ideas')}</h2>
         <ul className="mt-3 list-disc space-y-2 pl-6 text-sm text-slate-700">
-          <li>Write the key vocabulary words in your science notebook. Add a short definition in English.</li>
-          <li>Summarize the lesson in three sentences. Focus on the main idea and an example.</li>
-          <li>Teach a friend using the animation. Explain each step using the new words.</li>
+          {practiceIdeas.map((idea, index) => (
+            <li key={index}>{idea}</li>
+          ))}
         </ul>
       </section>
     </article>

--- a/src/pages/NotFoundPage.jsx
+++ b/src/pages/NotFoundPage.jsx
@@ -1,17 +1,20 @@
 import { Link } from 'react-router-dom';
+import { useLanguage } from '../context/LanguageContext.jsx';
 
 const NotFoundPage = () => {
+  const { t } = useLanguage();
   return (
     <div className="mx-auto max-w-3xl px-4 py-20 text-center">
-      <h1 className="text-4xl font-display font-semibold text-slate-900">Page not found</h1>
-      <p className="mt-4 text-sm text-slate-600">
-        The page you are looking for does not exist. Use the navigation bar or explore our main subjects.
-      </p>
+      <h1 className="text-4xl font-display font-semibold text-slate-900">{t('notFound.title', 'Page not found')}</h1>
+      <p className="mt-4 text-sm text-slate-600">{t(
+        'notFound.description',
+        'The page you are looking for does not exist. Use the navigation bar or explore our main subjects.'
+      )}</p>
       <Link
         to="/"
         className="mt-6 inline-block rounded-full bg-brand px-6 py-3 text-sm font-semibold text-white shadow hover:bg-brand-dark"
       >
-        Back to home
+        {t('notFound.backHome', 'Back to home')}
       </Link>
     </div>
   );

--- a/src/pages/QuizzesPage.jsx
+++ b/src/pages/QuizzesPage.jsx
@@ -1,15 +1,23 @@
 import QuizCard from '../components/QuizCard';
 import { quizzes } from '../data/quizzes';
+import { useLanguage } from '../context/LanguageContext.jsx';
 
 const QuizzesPage = () => {
+  const { t } = useLanguage();
   return (
     <div className="mx-auto max-w-5xl space-y-10 px-4 py-10">
       <header className="space-y-4">
-        <p className="text-xs font-semibold uppercase tracking-wide text-brand-dark">Interactive quizzes</p>
-        <h1 className="text-3xl font-display font-semibold text-slate-900">Lead with English, review science</h1>
+        <p className="text-xs font-semibold uppercase tracking-wide text-brand-dark">
+          {t('quizzesPage.eyebrow', 'Interactive quizzes')}
+        </p>
+        <h1 className="text-3xl font-display font-semibold text-slate-900">
+          {t('quizzesPage.heading', 'Lead with English, review science')}
+        </h1>
         <p className="text-sm text-slate-600">
-          Start with the English for Science Communication quiz, then try the extension quizzes for Physics, Chemistry,
-          Biology, and Earth Science. Read each explanation to strengthen your academic English vocabulary.
+          {t(
+            'quizzesPage.description',
+            'Start with the English for Science Communication quiz, then try the extension quizzes for Physics, Chemistry, Biology, and Earth Science. Read each explanation to strengthen your academic English vocabulary.'
+          )}
         </p>
       </header>
       <div className="grid gap-6 md:grid-cols-2">

--- a/src/pages/ResourcesPage.jsx
+++ b/src/pages/ResourcesPage.jsx
@@ -1,22 +1,27 @@
 import ResourceCard from '../components/ResourceCard';
+import { useLanguage } from '../context/LanguageContext.jsx';
 
 const resources = [
   {
+    id: 'nasa',
     title: 'NASA Climate Kids',
     description: 'Colorful articles, videos, and games that explain Earth Science topics for young learners.',
     url: 'https://climatekids.nasa.gov/'
   },
   {
+    id: 'physicsClassroom',
     title: 'Physics Classroom Tutorials',
     description: 'Interactive explanations, diagrams, and practice questions that cover core Physics ideas.',
     url: 'https://www.physicsclassroom.com/'
   },
   {
+    id: 'khanChemistry',
     title: 'Khan Academy Chemistry',
     description: 'Short video lessons and practice for atomic structure, bonding, and chemical reactions.',
     url: 'https://www.khanacademy.org/science/chemistry'
   },
   {
+    id: 'biodigital',
     title: 'BioDigital Human',
     description: '3D models and animations of the human body to support Biology studies.',
     url: 'https://www.biodigital.com/'
@@ -24,14 +29,21 @@ const resources = [
 ];
 
 const ResourcesPage = () => {
+  const { t } = useLanguage();
   return (
     <div className="mx-auto max-w-5xl space-y-10 px-4 py-10">
       <header className="space-y-4">
-        <p className="text-xs font-semibold uppercase tracking-wide text-brand-dark">Resources</p>
-        <h1 className="text-3xl font-display font-semibold text-slate-900">Extra study tools</h1>
+        <p className="text-xs font-semibold uppercase tracking-wide text-brand-dark">
+          {t('resourcesPage.eyebrow', 'Resources')}
+        </p>
+        <h1 className="text-3xl font-display font-semibold text-slate-900">
+          {t('resourcesPage.heading', 'Extra study tools')}
+        </h1>
         <p className="text-sm text-slate-600">
-          Explore safe websites that offer videos, animations, articles, and downloadable worksheets. Use these tools to review
-          lessons or extend your learning in English.
+          {t(
+            'resourcesPage.description',
+            'Explore safe websites that offer videos, animations, articles, and downloadable worksheets. Use these tools to review lessons or extend your learning in English.'
+          )}
         </p>
       </header>
       <div className="grid gap-6 md:grid-cols-2">

--- a/src/pages/SubjectDetailPage.jsx
+++ b/src/pages/SubjectDetailPage.jsx
@@ -2,23 +2,36 @@ import { useMemo } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import LessonCard from '../components/LessonCard';
 import { subjects } from '../data/lessons';
+import { useLanguage } from '../context/LanguageContext.jsx';
 
 const SubjectDetailPage = ({ progress, onComplete }) => {
   const { subjectId } = useParams();
+  const { t } = useLanguage();
   const subject = useMemo(() => subjects.find((item) => item.id === subjectId), [subjectId]);
-  const badgeLabel = subject?.id === 'english-for-science' ? 'Core English Subject' : 'Extension Module';
+  const badgeLabel = subject
+    ? subject.id === 'english-for-science'
+      ? t('subjectsPage.coreBadge', 'Core English Subject')
+      : t('subjectsPage.extensionBadge', 'Extension Module')
+    : '';
 
   if (!subject) {
     return (
       <div className="mx-auto max-w-4xl px-4 py-20 text-center">
-        <h1 className="text-3xl font-display font-semibold text-slate-900">Subject not found</h1>
-        <p className="mt-3 text-sm text-slate-600">Please return to the subjects page and choose a different topic.</p>
+        <h1 className="text-3xl font-display font-semibold text-slate-900">
+          {t('subjectsPage.subjectNotFound', 'Subject not found')}
+        </h1>
+        <p className="mt-3 text-sm text-slate-600">
+          {t('subjectsPage.subjectNotFoundMessage', 'Please return to the subjects page and choose a different topic.')}
+        </p>
         <Link to="/subjects" className="mt-6 inline-block rounded-full bg-brand px-6 py-3 text-sm font-semibold text-white">
-          Back to subjects
+          {t('lessonPage.backToSubjects', 'Back to subjects')}
         </Link>
       </div>
     );
   }
+
+  const title = t(['subjects', subject.id, 'title'], subject.title);
+  const overview = t(['subjects', subject.id, 'overview'], subject.overview);
 
   return (
     <div className="mx-auto max-w-5xl space-y-10 px-4">
@@ -26,11 +39,13 @@ const SubjectDetailPage = ({ progress, onComplete }) => {
         style={{ backgroundImage: `linear-gradient(120deg, rgba(14,165,233,0.8), rgba(236,72,153,0.7)), url(${subject.heroImage})` }}
       >
         <p className="text-xs font-semibold uppercase tracking-[0.3em]">{badgeLabel}</p>
-        <h1 className="mt-3 text-4xl font-display font-semibold">{subject.title}</h1>
-        <p className="mt-4 max-w-2xl text-sm text-slate-100">{subject.overview}</p>
+        <h1 className="mt-3 text-4xl font-display font-semibold">{title}</h1>
+        <p className="mt-4 max-w-2xl text-sm text-slate-100">{overview}</p>
       </header>
       <section className="space-y-6">
-        <h2 className="text-2xl font-display font-semibold text-slate-900">Lesson collection</h2>
+        <h2 className="text-2xl font-display font-semibold text-slate-900">
+          {t('subjectsPage.lessonCollection', 'Lesson collection')}
+        </h2>
         <div className="space-y-6">
           {subject.lessons.map((lesson) => (
             <LessonCard

--- a/src/pages/SubjectsPage.jsx
+++ b/src/pages/SubjectsPage.jsx
@@ -5,9 +5,11 @@ import SubjectCard from '../components/SubjectCard';
 import LessonCard from '../components/LessonCard';
 import ProgressTracker from '../components/ProgressTracker';
 import { subjects, allLessons } from '../data/lessons';
+import { useLanguage } from '../context/LanguageContext.jsx';
 
 const SubjectsPage = ({ query, setQuery, progress, onComplete, onResetProgress }) => {
   const location = useLocation();
+  const { t } = useLanguage();
 
   useEffect(() => {
     if (location.state?.query) {
@@ -28,13 +30,26 @@ const SubjectsPage = ({ query, setQuery, progress, onComplete, onResetProgress }
   return (
     <div className="mx-auto max-w-6xl space-y-12 px-4">
       <header className="space-y-4 pt-8">
-        <p className="text-xs font-semibold uppercase tracking-wide text-brand-dark">Learn by topic</p>
-        <h1 className="text-3xl font-display font-semibold text-slate-900">English core lessons and science extensions</h1>
-        <p className="text-sm text-slate-600">
-          Search the English for Science lessons first, then explore extension modules in Physics, Chemistry, Biology, and
-          Earth Science. Explanations use simple academic English to support multilingual learners.
+        <p className="text-xs font-semibold uppercase tracking-wide text-brand-dark">
+          {t('subjectsPage.eyebrow', 'Learn by topic')}
         </p>
-        <SearchBar query={query} setQuery={setQuery} placeholder="Search lesson titles, subjects, or key words" />
+        <h1 className="text-3xl font-display font-semibold text-slate-900">
+          {t('subjectsPage.heading', 'English core lessons and science extensions')}
+        </h1>
+        <p className="text-sm text-slate-600">
+          {t(
+            'subjectsPage.description',
+            'Search the English for Science lessons first, then explore extension modules in Physics, Chemistry, Biology, and Earth Science. Explanations use simple academic English to support multilingual learners.'
+          )}
+        </p>
+        <SearchBar
+          query={query}
+          setQuery={setQuery}
+          placeholder={t(
+            'subjectsPage.searchPlaceholder',
+            'Search lesson titles, subjects, or key words'
+          )}
+        />
       </header>
 
       <div className="grid gap-6 md:grid-cols-[2fr,1fr]">
@@ -42,7 +57,9 @@ const SubjectsPage = ({ query, setQuery, progress, onComplete, onResetProgress }
           {normalizedQuery && (
             <section className="space-y-4 rounded-3xl border border-brand/30 bg-white p-6 shadow-sm">
               <h2 className="text-lg font-semibold text-slate-900">
-                {filteredLessons.length} lesson{filteredLessons.length === 1 ? '' : 's'} found
+                {filteredLessons.length === 1
+                  ? t('subjectsPage.resultsSingular', `Found {count} lesson`, { count: filteredLessons.length })
+                  : t('subjectsPage.resultsPlural', `Found {count} lessons`, { count: filteredLessons.length })}
               </h2>
               <div className="space-y-4">
                 {filteredLessons.map((lesson) => (
@@ -59,7 +76,9 @@ const SubjectsPage = ({ query, setQuery, progress, onComplete, onResetProgress }
           )}
 
           <section className="space-y-4">
-            <h2 className="text-lg font-semibold text-slate-900">Browse English core + science extensions</h2>
+            <h2 className="text-lg font-semibold text-slate-900">
+              {t('subjectsPage.browseHeading', 'Browse English core + science extensions')}
+            </h2>
             <div className="grid gap-6 md:grid-cols-2">
               {subjects.map((subject) => (
                 <SubjectCard key={subject.id} subject={subject} />


### PR DESCRIPTION
## Summary
- add a LanguageProvider with persistent toggle and translation helper
- localize navigation, pages, and shared components with Vietnamese copy and new translation catalog
- translate static lesson, quiz, word-of-day, and forum content for Vietnamese display

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e8579bde50833182f037c3980d66d1