### PR TITLE
Revamp interface with dark OJ-inspired styling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -54,7 +54,7 @@ const App = () => {
   };
 
   return (
-    <div className="flex min-h-screen flex-col bg-slate-50">
+    <div className="flex min-h-screen flex-col text-slate-100">
       <Navbar onSearch={setSearchQuery} user={user} onLogout={handleLogout} />
       <main className="flex-1 pb-20">
         <Routes>

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -5,15 +5,21 @@ const Hero = () => {
   const { t } = useLanguage();
 
   return (
-    <section className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-brand-light via-white to-accent-light px-6 py-16 shadow-lg">
-      <div className="relative z-10 mx-auto max-w-3xl text-center">
-        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-dark">
+    <section className="relative overflow-hidden rounded-3xl border border-slate-800/60 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 px-6 py-16 shadow-[0_35px_120px_-40px_rgba(2,6,23,0.9)]">
+      <div className="pointer-events-none absolute inset-0 opacity-80" aria-hidden>
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(56,189,248,0.35),transparent_55%)]" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom_right,rgba(8,47,73,0.35),transparent_50%)]" />
+        <div className="absolute inset-0 bg-[linear-gradient(130deg,rgba(15,23,42,0.2)_0%,rgba(15,23,42,0.6)_45%,rgba(2,6,23,0.9)_100%)]" />
+        <div className="absolute inset-0 bg-[url('data:image/svg+xml,%3Csvg width=\'160\' height=\'160\' xmlns=\'http://www.w3.org/2000/svg\'%3E%3Cdefs%3E%3ClinearGradient id=\'g\' x1=\'0%25\' y1=\'0%25\' x2=\'100%25\' y2=\'100%25\'%3E%3Cstop stop-color=\'%23080F1F\' stop-opacity=\'0.35\' offset=\'0%25\'/%3E%3Cstop stop-color=\'%23080F1F\' stop-opacity=\'0\' offset=\'100%25\'/%3E%3C/linearGradient%3E%3Cpattern id=\'p\' width=\'32\' height=\'32\' patternUnits=\'userSpaceOnUse\'%3E%3Cpath d=\'M32 0H0v32\' fill=\'none\' stroke=\'%230d1b3d\' stroke-opacity=\'0.3\' stroke-width=\'1\'/%3E%3C/pattern%3E%3C/defs%3E%3Crect fill=\'url(%23p)\' width=\'160\' height=\'160\'/%3E%3Crect fill=\'url(%23g)\' width=\'160\' height=\'160\'/%3E%3C/svg%3E')]" />
+      </div>
+      <div className="relative z-10 mx-auto max-w-4xl text-center">
+        <p className="text-xs font-semibold uppercase tracking-[0.35em] text-brand/70">
           {t('hero.eyebrow', 'English-first learning')}
         </p>
-        <h1 className="mt-4 font-display text-4xl font-semibold text-slate-900 md:text-5xl">
+        <h1 className="mt-4 font-display text-4xl font-semibold text-white md:text-5xl">
           {t('hero.heading', 'Master English to unlock every science story')}
         </h1>
-        <p className="mt-4 text-base text-slate-600 md:text-lg">
+        <p className="mt-4 text-base text-slate-300 md:text-lg">
           {t(
             'hero.description',
             'Start with Academic English for Science, then extend your skills to Physics, Chemistry, Biology, and Earth Science. Learn with visuals, short videos, interactive quizzes, and vocabulary adapted from Oxford and Cambridge resources.'
@@ -22,20 +28,38 @@ const Hero = () => {
         <div className="mt-8 flex flex-wrap items-center justify-center gap-4">
           <Link
             to="/subjects"
-            className="rounded-full bg-brand px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-brand/30 transition hover:bg-brand-dark"
+            className="rounded-full bg-brand px-6 py-3 text-sm font-semibold text-white shadow-[0_10px_35px_rgba(56,189,248,0.35)] transition hover:bg-brand-dark"
           >
             {t('hero.primaryCta', 'Explore subjects')}
           </Link>
           <Link
             to="/quizzes"
-            className="rounded-full border border-brand bg-white px-6 py-3 text-sm font-semibold text-brand transition hover:bg-brand-light/60"
+            className="rounded-full border border-slate-700/80 bg-transparent px-6 py-3 text-sm font-semibold text-slate-200 transition hover:border-brand hover:text-white"
           >
             {t('hero.secondaryCta', 'Try a quiz')}
           </Link>
         </div>
+        <div className="mt-12 grid gap-4 text-left sm:grid-cols-3">
+          <div className="rounded-2xl border border-slate-800 bg-slate-900/70 px-4 py-3 shadow-inner shadow-slate-900/40">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+              {t('hero.metricLessonsEyebrow', 'Guided modules')}
+            </p>
+            <p className="mt-2 text-2xl font-semibold text-white">{t('hero.metricLessons', '40+ lessons')}</p>
+          </div>
+          <div className="rounded-2xl border border-slate-800 bg-slate-900/70 px-4 py-3 shadow-inner shadow-slate-900/40">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+              {t('hero.metricPracticeEyebrow', 'Practice questions')}
+            </p>
+            <p className="mt-2 text-2xl font-semibold text-white">{t('hero.metricPractice', '180+ prompts')}</p>
+          </div>
+          <div className="rounded-2xl border border-slate-800 bg-slate-900/70 px-4 py-3 shadow-inner shadow-slate-900/40">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+              {t('hero.metricCommunityEyebrow', 'Learner community')}
+            </p>
+            <p className="mt-2 text-2xl font-semibold text-white">{t('hero.metricCommunity', 'Forum + chatbot')}</p>
+          </div>
+        </div>
       </div>
-      <div className="pointer-events-none absolute -top-10 left-1/2 h-56 w-56 -translate-x-1/2 rounded-full bg-brand/20 blur-3xl" aria-hidden />
-      <div className="pointer-events-none absolute -bottom-24 right-12 h-64 w-64 rounded-full bg-accent/20 blur-3xl" aria-hidden />
     </section>
   );
 };

--- a/src/components/LessonCard.jsx
+++ b/src/components/LessonCard.jsx
@@ -8,19 +8,19 @@ const LessonCard = ({ lesson, subjectId, isCompleted, onComplete }) => {
   const summary = t(['lessons', subjectId, lesson.id, 'summary'], lesson.summary);
   const keyVocabulary = t(['lessons', subjectId, lesson.id, 'keyVocabulary'], lesson.keyVocabulary);
   return (
-    <article className="flex flex-col gap-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+    <article className="flex flex-col gap-4 rounded-3xl border border-slate-800/70 bg-slate-900/70 p-6 shadow-lg shadow-slate-950/40">
       <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-        <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
-        <div className="flex items-center gap-2 text-xs text-slate-500">
+        <h3 className="text-lg font-semibold text-white">{title}</h3>
+        <div className="flex items-center gap-2 text-xs text-slate-400">
           <FiBookOpen aria-hidden />
           <span>{t('lessonCard.keyWords', `${keyVocabulary.length} key words`, { count: keyVocabulary.length })}</span>
         </div>
       </div>
-      <p className="text-sm text-slate-600">{summary}</p>
-      <img src={lesson.image} alt={title} className="h-40 w-full object-cover" />
+      <p className="text-sm text-slate-300">{summary}</p>
+      <img src={lesson.image} alt={title} className="h-40 w-full rounded-2xl border border-slate-800/70 object-cover" />
       <div className="flex flex-wrap gap-2 text-xs text-brand">
         {keyVocabulary.map((word) => (
-          <span key={word} className="rounded-full bg-brand-light/60 px-3 py-1 text-brand-dark">
+          <span key={word} className="rounded-full border border-slate-700/80 bg-slate-950/80 px-3 py-1 text-slate-200">
             {word}
           </span>
         ))}
@@ -35,7 +35,9 @@ const LessonCard = ({ lesson, subjectId, isCompleted, onComplete }) => {
         <button
           onClick={() => onComplete?.(lesson.id)}
           className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold transition ${
-            isCompleted ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-100 text-slate-600 hover:bg-brand-light/60 hover:text-brand-dark'
+            isCompleted
+              ? 'border border-emerald-400/60 bg-emerald-500/15 text-emerald-200'
+              : 'border border-slate-700 bg-slate-950/70 text-slate-200 hover:border-brand/50 hover:text-white'
           }`}
         >
           <FiCheckCircle aria-hidden />

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -37,28 +37,28 @@ const Navbar = ({ onSearch, user, onLogout }) => {
   };
 
   return (
-    <header className="sticky top-0 z-50 bg-gradient-to-b from-white/95 via-white/90 to-white/80 backdrop-blur">
-      <div className="mx-auto max-w-6xl px-4 py-4">
-        <nav className="flex flex-wrap items-center gap-x-4 gap-y-3 rounded-3xl border border-white/60 bg-white/95 px-4 py-3 shadow-lg shadow-brand/10 lg:flex-nowrap">
+    <header className="sticky top-0 z-50 border-b border-slate-800/80 bg-slate-950/80 backdrop-blur">
+      <div className="mx-auto max-w-7xl px-4">
+        <nav className="flex h-20 items-center gap-4">
           <Link
             to="/"
-            className="flex shrink-0 items-center gap-3 text-lg font-display font-semibold text-brand-dark transition hover:opacity-90"
+            className="flex items-center gap-3 rounded-2xl border border-slate-800/60 bg-slate-900/80 px-4 py-2 text-lg font-display font-semibold text-white shadow-[0_0_20px_rgba(15,23,42,0.45)] transition hover:border-brand/70"
           >
-            <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-brand-light text-base font-bold text-brand-dark shadow-inner">
+            <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-brand/20 text-sm font-bold uppercase tracking-wide text-brand">
               SB
             </span>
             <span className="hidden sm:inline">SciBridge</span>
           </Link>
-          <div className="hidden w-full flex-wrap items-center justify-center gap-1 md:flex md:w-full lg:w-auto">
+          <div className="hidden flex-1 items-center justify-center gap-1 md:flex">
             {navItems.map((item) => (
               <NavLink
                 key={item.path}
                 to={item.path}
                 className={({ isActive }) =>
-                  `rounded-full px-4 py-2 text-sm font-medium transition-colors ${
+                  `relative rounded-full px-3 py-2 text-sm font-semibold transition ${
                     isActive
-                      ? 'bg-brand text-white shadow-sm shadow-brand/30'
-                      : 'text-slate-600 hover:bg-brand-light/50 hover:text-brand-dark'
+                      ? "text-white after:absolute after:left-3 after:right-3 after:-bottom-1 after:h-0.5 after:rounded-full after:bg-brand after:content-['']"
+                      : "text-slate-300 hover:text-white hover:after:absolute hover:after:left-3 hover:after:right-3 hover:after:-bottom-1 hover:after:h-0.5 hover:after:rounded-full hover:after:bg-slate-700 hover:after:content-['']"
                   }`
                 }
               >
@@ -66,14 +66,14 @@ const Navbar = ({ onSearch, user, onLogout }) => {
               </NavLink>
             ))}
           </div>
-          <div className="hidden w-full items-center justify-center gap-3 md:flex md:w-full md:flex-wrap lg:w-auto lg:flex-nowrap lg:justify-end">
-            <form onSubmit={handleSubmit} className="relative w-full md:max-w-xs lg:w-auto">
-              <FiSearch className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-slate-400" aria-hidden />
+          <div className="hidden items-center gap-3 md:flex">
+            <form onSubmit={handleSubmit} className="relative">
+              <FiSearch className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-slate-500" aria-hidden />
               <input
                 type="search"
                 value={query}
                 onChange={(event) => setQuery(event.target.value)}
-                className="w-full rounded-full border border-slate-200 bg-slate-50 py-2 pl-10 pr-4 text-sm font-medium text-slate-600 transition focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30 md:w-full lg:w-48"
+                className="w-48 rounded-full border border-slate-800 bg-slate-900/70 py-2 pl-11 pr-4 text-sm font-medium text-slate-200 transition focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/40"
                 placeholder={t('navbar.searchPlaceholder', 'Search lessons')}
                 aria-label={t('navbar.searchAria', 'Search lessons')}
               />
@@ -84,21 +84,21 @@ const Navbar = ({ onSearch, user, onLogout }) => {
                 toggleLanguage();
                 setIsOpen(false);
               }}
-              className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-600 transition hover:border-brand hover:bg-brand-light/40 hover:text-brand-dark"
+              className="inline-flex items-center gap-2 rounded-full border border-slate-800 bg-slate-900/80 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200 transition hover:border-brand/70 hover:text-white"
               aria-label={t('navbar.languageToggle', 'Switch language')}
             >
               <FiGlobe aria-hidden />
               {language === 'en' ? 'EN' : 'VI'}
             </button>
             {user ? (
-              <div className="flex items-center gap-3 rounded-full border border-brand/20 bg-brand-light/40 px-3 py-1.5 text-sm font-semibold text-brand-dark">
-                <span className="hidden xl:inline">{t('navbar.greeting', `Hi, {name}`, { name: user.name })}</span>
-                <span className="rounded-full bg-white/80 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-brand-dark">
+              <div className="flex items-center gap-3 rounded-full border border-brand/40 bg-brand/10 px-3 py-1.5 text-sm font-semibold text-brand">
+                <span className="hidden xl:inline text-slate-200">{t('navbar.greeting', `Hi, {name}`, { name: user.name })}</span>
+                <span className="rounded-full bg-slate-950/60 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-brand">
                   {t('navbar.role', 'Role')}: {user.role}
                 </span>
                 <button
                   type="button"
-                  className="rounded-full bg-brand-dark px-3 py-1 text-xs font-semibold text-white shadow-sm transition hover:bg-brand"
+                  className="rounded-full bg-brand px-3 py-1 text-xs font-semibold text-white shadow-sm transition hover:bg-brand-dark"
                   onClick={() => {
                     onLogout?.();
                     setIsOpen(false);
@@ -117,7 +117,7 @@ const Navbar = ({ onSearch, user, onLogout }) => {
             )}
           </div>
           <button
-            className="ml-auto inline-flex items-center justify-center rounded-full border border-slate-200 p-2 text-slate-600 transition hover:border-brand hover:text-brand-dark md:hidden"
+            className="ml-auto inline-flex items-center justify-center rounded-full border border-slate-800 bg-slate-900/80 p-2 text-slate-200 transition hover:border-brand/70 hover:text-white md:hidden"
             onClick={() => setIsOpen((prev) => !prev)}
             aria-label="Toggle navigation"
           >
@@ -126,14 +126,14 @@ const Navbar = ({ onSearch, user, onLogout }) => {
         </nav>
       </div>
       {isOpen && (
-        <div className="border-t border-slate-100 bg-white px-4 py-5 md:hidden">
+        <div className="border-t border-slate-800/60 bg-slate-950/95 px-4 py-5 md:hidden">
           <form onSubmit={handleSubmit} className="relative mb-5">
-            <FiSearch className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" aria-hidden />
+            <FiSearch className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-500" aria-hidden />
             <input
               type="search"
               value={query}
               onChange={(event) => setQuery(event.target.value)}
-              className="w-full rounded-full border border-slate-200 bg-slate-50 py-2 pl-9 pr-4 text-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30"
+              className="w-full rounded-full border border-slate-800 bg-slate-900/80 py-2 pl-11 pr-4 text-sm text-slate-200 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/40"
               placeholder={t('navbar.searchPlaceholder', 'Search lessons')}
               aria-label={t('navbar.searchAria', 'Search lessons')}
             />
@@ -145,8 +145,10 @@ const Navbar = ({ onSearch, user, onLogout }) => {
                 to={item.path}
                 onClick={() => setIsOpen(false)}
                 className={({ isActive }) =>
-                  `rounded-lg px-3 py-2 text-sm font-semibold hover:bg-brand-light/40 ${
-                    isActive ? 'bg-brand-light/50 text-brand-dark' : 'text-slate-600'
+                  `rounded-xl px-3 py-2 text-sm font-semibold transition ${
+                    isActive
+                      ? 'border border-brand/50 bg-brand/15 text-white'
+                      : 'border border-slate-800 bg-slate-900/70 text-slate-200 hover:border-brand/40 hover:text-white'
                   }`
                 }
               >
@@ -159,13 +161,13 @@ const Navbar = ({ onSearch, user, onLogout }) => {
                 toggleLanguage();
                 setIsOpen(false);
               }}
-              className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-left text-sm font-semibold text-slate-600 transition hover:border-brand hover:bg-brand-light/40 hover:text-brand-dark"
+              className="rounded-xl border border-slate-800 bg-slate-900/80 px-3 py-2 text-left text-sm font-semibold text-slate-200 transition hover:border-brand/60 hover:text-white"
             >
               <span className="inline-flex items-center gap-2">
                 <FiGlobe aria-hidden />
                 {t('navbar.languageToggle', 'Switch language')}
               </span>
-              <span className="mt-1 block text-xs uppercase tracking-wide text-slate-400">{language === 'en' ? 'English' : 'Tiếng Việt'}</span>
+              <span className="mt-1 block text-xs uppercase tracking-wide text-slate-500">{language === 'en' ? 'English' : 'Tiếng Việt'}</span>
             </button>
             {user ? (
               <button
@@ -174,7 +176,7 @@ const Navbar = ({ onSearch, user, onLogout }) => {
                   onLogout?.();
                   setIsOpen(false);
                 }}
-                className="rounded-lg bg-brand-dark px-3 py-2 text-left text-sm font-semibold text-white shadow-sm hover:bg-brand"
+                className="rounded-xl bg-brand px-3 py-2 text-left text-sm font-semibold text-white shadow-sm hover:bg-brand-dark"
               >
                 {t('navbar.signOutWithName', 'Sign out {name}', { name: user.name })}
               </button>
@@ -182,7 +184,7 @@ const Navbar = ({ onSearch, user, onLogout }) => {
               <NavLink
                 to="/forum"
                 onClick={() => setIsOpen(false)}
-                className="rounded-lg bg-brand px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-dark"
+                className="rounded-xl bg-brand px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-dark"
               >
                 {t('navbar.joinForumMobile', 'Join the Forum')}
               </NavLink>

--- a/src/components/ProgressTracker.jsx
+++ b/src/components/ProgressTracker.jsx
@@ -6,28 +6,28 @@ const ProgressTracker = ({ progress, totalLessons, onReset }) => {
   const percentage = totalLessons ? Math.round((completedCount / totalLessons) * 100) : 0;
 
   return (
-    <section className="flex flex-col gap-4 rounded-3xl border border-emerald-200 bg-emerald-50 p-6 text-emerald-700">
+    <section className="flex flex-col gap-4 rounded-3xl border border-slate-800/70 bg-slate-900/70 p-6 text-slate-200 shadow-lg shadow-slate-950/40">
       <div>
-        <p className="text-xs font-semibold uppercase tracking-wide">{t('progress.title', 'Learning Progress')}</p>
-        <h3 className="mt-2 text-2xl font-display font-semibold">
+        <p className="text-xs font-semibold uppercase tracking-wide text-brand/80">{t('progress.title', 'Learning Progress')}</p>
+        <h3 className="mt-2 text-2xl font-display font-semibold text-white">
           {t('progress.percentage', `${percentage}% complete`, { percentage })}
         </h3>
-        <p className="mt-1 text-sm text-emerald-700/80">
+        <p className="mt-1 text-sm text-slate-300">
           {t('progress.summary', `You have finished ${completedCount} of ${totalLessons} lessons. Keep going!`, {
             completed: completedCount,
             total: totalLessons
           })}
         </p>
       </div>
-      <div className="h-3 w-full rounded-full bg-emerald-100">
+      <div className="h-3 w-full rounded-full bg-slate-800">
         <div
-          className="h-full rounded-full bg-emerald-400 transition-all"
+          className="h-full rounded-full bg-brand transition-all"
           style={{ width: `${percentage}%` }}
         />
       </div>
       <button
         onClick={onReset}
-        className="self-start rounded-full bg-white px-4 py-2 text-xs font-semibold text-emerald-600 shadow-sm hover:bg-emerald-100"
+        className="self-start rounded-full border border-brand/50 bg-brand/10 px-4 py-2 text-xs font-semibold text-brand transition hover:bg-brand/20"
       >
         {t('progress.reset', 'Reset progress')}
       </button>

--- a/src/components/QuizCard.jsx
+++ b/src/components/QuizCard.jsx
@@ -31,28 +31,28 @@ const QuizCard = ({ quiz }) => {
   };
 
   return (
-    <section className="flex flex-col gap-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+    <section className="flex flex-col gap-4 rounded-3xl border border-slate-800/70 bg-slate-900/70 p-6 shadow-lg shadow-slate-950/40">
       <div className="flex flex-col gap-2">
-        <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
-        <p className="text-sm text-slate-600">{description}</p>
+        <h3 className="text-lg font-semibold text-white">{title}</h3>
+        <p className="text-sm text-slate-300">{description}</p>
       </div>
-      <div className="rounded-2xl bg-slate-50 p-4">
+      <div className="rounded-2xl border border-slate-800/70 bg-slate-950/60 p-4">
         <p className="text-sm font-semibold text-brand">
           {t('quizzesPage.questionLabel', `Question {index}`, { index: currentQuestion + 1 })}
         </p>
-        <p className="mt-2 text-base font-medium text-slate-900">{prompt}</p>
+        <p className="mt-2 text-base font-medium text-white">{prompt}</p>
         <ul className="mt-4 space-y-3">
           {options.map((option, index) => {
             const isSelected = selectedOption === index;
             const isAnswer = question.answerIndex === index;
             const statusClass =
               isCorrect === null
-                ? 'border-slate-200 bg-white hover:border-brand'
+                ? 'border-slate-700/60 bg-slate-900/70 text-slate-200 hover:border-brand/40'
                 : isAnswer
-                ? 'border-emerald-300 bg-emerald-50 text-emerald-700'
+                ? 'border-emerald-400/70 bg-emerald-500/10 text-emerald-200'
                 : isSelected
-                ? 'border-rose-300 bg-rose-50 text-rose-600'
-                : 'border-slate-200 bg-white';
+                ? 'border-rose-500/70 bg-rose-500/10 text-rose-200'
+                : 'border-slate-800 bg-slate-900/70 text-slate-300';
             return (
               <li key={option}>
                 <button
@@ -60,9 +60,9 @@ const QuizCard = ({ quiz }) => {
                   className={`flex w-full items-center justify-between rounded-2xl border px-4 py-3 text-left text-sm font-medium transition ${statusClass}`}
                 >
                   <span>{option}</span>
-                  {isCorrect !== null && isAnswer && <FiCheckCircle className="text-emerald-500" aria-hidden />}
+                  {isCorrect !== null && isAnswer && <FiCheckCircle className="text-emerald-300" aria-hidden />}
                   {isCorrect !== null && isSelected && !isAnswer && (
-                    <FiXCircle className="text-rose-500" aria-hidden />
+                    <FiXCircle className="text-rose-300" aria-hidden />
                   )}
                 </button>
               </li>
@@ -71,8 +71,10 @@ const QuizCard = ({ quiz }) => {
         </ul>
         {isCorrect !== null && (
           <div
-            className={`mt-4 rounded-2xl px-4 py-3 text-sm ${
-              isCorrect ? 'bg-emerald-50 text-emerald-700' : 'bg-rose-50 text-rose-600'
+            className={`mt-4 rounded-2xl border px-4 py-3 text-sm ${
+              isCorrect
+                ? 'border-emerald-400/60 bg-emerald-500/10 text-emerald-200'
+                : 'border-rose-500/60 bg-rose-500/10 text-rose-200'
             }`}
           >
             {explanation}
@@ -82,7 +84,7 @@ const QuizCard = ({ quiz }) => {
       <div className="flex justify-end">
         <button
           onClick={handleNext}
-          className="rounded-full bg-brand px-4 py-2 text-sm font-semibold text-white shadow hover:bg-brand-dark"
+          className="rounded-full bg-brand px-4 py-2 text-sm font-semibold text-white shadow-[0_10px_25px_rgba(56,189,248,0.25)] transition hover:bg-brand-dark"
         >
           {t('quizzesPage.nextQuestion', 'Next question')}
         </button>

--- a/src/components/ResourceCard.jsx
+++ b/src/components/ResourceCard.jsx
@@ -4,9 +4,9 @@ const ResourceCard = ({ resource }) => {
   const { t } = useLanguage();
   const description = t(['resources', resource.id, 'description'], resource.description);
   return (
-    <article className="flex flex-col gap-3 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-      <h3 className="text-lg font-semibold text-slate-900">{resource.title}</h3>
-      <p className="text-sm text-slate-600">{description}</p>
+    <article className="flex flex-col gap-3 rounded-3xl border border-slate-800/70 bg-slate-900/70 p-6 shadow-lg shadow-slate-950/40">
+      <h3 className="text-lg font-semibold text-white">{resource.title}</h3>
+      <p className="text-sm text-slate-300">{description}</p>
       <a
         href={resource.url}
         target="_blank"

--- a/src/components/ScienceChatbot.jsx
+++ b/src/components/ScienceChatbot.jsx
@@ -66,9 +66,9 @@ const ScienceChatbot = () => {
   };
 
   return (
-    <section className="flex h-full flex-col rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-      <h3 className="text-lg font-semibold text-slate-900">{t('chatbot.title', 'Science Helper Chatbot')}</h3>
-      <p className="mt-1 text-sm text-slate-600">
+    <section className="flex h-full flex-col rounded-3xl border border-slate-800/70 bg-slate-900/70 p-6 shadow-lg shadow-slate-950/40">
+      <h3 className="text-lg font-semibold text-white">{t('chatbot.title', 'Science Helper Chatbot')}</h3>
+      <p className="mt-1 text-sm text-slate-300">
         {t('chatbot.description', 'Type a topic keyword and receive an easy English explanation.')}
       </p>
       <div className="mt-4 flex-1 space-y-3 overflow-y-auto">
@@ -77,8 +77,8 @@ const ScienceChatbot = () => {
             key={index}
             className={`max-w-[85%] rounded-2xl px-4 py-3 text-sm ${
               message.sender === 'bot'
-                ? 'bg-brand-light/70 text-brand-dark'
-                : 'ml-auto bg-slate-900 text-white'
+                ? 'border border-brand/40 bg-brand/15 text-brand'
+                : 'ml-auto border border-slate-700 bg-slate-800/80 text-slate-100'
             }`}
           >
             {'text' in message
@@ -91,13 +91,13 @@ const ScienceChatbot = () => {
         <input
           value={input}
           onChange={(event) => setInput(event.target.value)}
-          className="flex-1 rounded-full border border-slate-200 bg-slate-50 px-4 py-2 text-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30"
+          className="flex-1 rounded-full border border-slate-800 bg-slate-950/60 px-4 py-2 text-sm text-slate-200 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/40"
           placeholder={t('chatbot.placeholder', 'Ask about force, atoms, ecosystems...')}
           aria-label="Chat message"
         />
         <button
           type="submit"
-          className="inline-flex items-center gap-2 rounded-full bg-brand px-4 py-2 text-sm font-semibold text-white shadow hover:bg-brand-dark"
+          className="inline-flex items-center gap-2 rounded-full bg-brand px-4 py-2 text-sm font-semibold text-white shadow-[0_10px_25px_rgba(56,189,248,0.25)] transition hover:bg-brand-dark"
         >
           {t('chatbot.send', 'Send')}
           <FiSend aria-hidden />

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -11,7 +11,7 @@ const SearchBar = ({ query, setQuery, placeholder = 'Search topics or keywords',
   return (
     <form
       onSubmit={handleSubmit}
-      className="flex w-full items-center gap-3 rounded-2xl border border-slate-200 bg-white px-4 py-3 shadow-sm"
+      className="flex w-full items-center gap-3 rounded-2xl border border-slate-800/70 bg-slate-950/60 px-4 py-3 shadow-inner shadow-slate-950/30"
     >
       <FiSearch className="text-xl text-brand" aria-hidden />
       <input
@@ -20,11 +20,11 @@ const SearchBar = ({ query, setQuery, placeholder = 'Search topics or keywords',
         type="search"
         placeholder={t('searchBar.placeholder', placeholder)}
         aria-label={t('searchBar.placeholder', placeholder)}
-        className="w-full bg-transparent text-sm focus:outline-none"
+        className="w-full bg-transparent text-sm text-slate-200 placeholder:text-slate-500 focus:outline-none"
       />
       <button
         type="submit"
-        className="rounded-full bg-brand px-4 py-2 text-sm font-semibold text-white shadow hover:bg-brand-dark"
+        className="rounded-full bg-brand px-4 py-2 text-sm font-semibold text-white shadow-[0_8px_20px_rgba(56,189,248,0.25)] transition hover:bg-brand-dark"
       >
         {t('searchBar.submit', 'Search')}
       </button>

--- a/src/components/SubjectCard.jsx
+++ b/src/components/SubjectCard.jsx
@@ -8,17 +8,22 @@ const SubjectCard = ({ subject }) => {
   const description = t(['subjects', subject.id, 'description'], subject.description);
   const keywords = t(['subjects', subject.id, 'keywords'], subject.keywords);
   return (
-    <article className="group flex flex-col overflow-hidden rounded-3xl bg-gradient-to-br p-[1px] shadow-lg transition hover:shadow-xl"
-      style={{ backgroundImage: `linear-gradient(135deg, rgba(56,189,248,0.4), rgba(236,72,153,0.4))` }}
-    >
-      <div className="flex flex-1 flex-col gap-4 rounded-[calc(1.5rem-1px)] bg-white p-6">
-        <img src={subject.heroImage} alt={`${title} illustration`} className="h-48 w-full object-cover" />
+    <article className="group relative flex flex-col overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/70 p-6 shadow-lg shadow-slate-950/50 transition hover:border-brand/50 hover:bg-slate-900">
+      <div className="pointer-events-none absolute inset-0 opacity-0 transition duration-500 group-hover:opacity-20" aria-hidden>
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(56,189,248,0.45),transparent_60%)]" />
+      </div>
+      <div className="relative z-10 flex flex-1 flex-col gap-5">
+        <img
+          src={subject.heroImage}
+          alt={`${title} illustration`}
+          className="h-44 w-full rounded-2xl border border-slate-800/70 object-cover"
+        />
         <div className="flex flex-1 flex-col">
-          <h3 className="text-xl font-semibold text-slate-900">{title}</h3>
-          <p className="mt-2 flex-1 text-sm text-slate-600">{description}</p>
+          <h3 className="text-xl font-semibold text-white">{title}</h3>
+          <p className="mt-2 flex-1 text-sm text-slate-300">{description}</p>
           <div className="mt-4 flex flex-wrap gap-2 text-xs font-medium text-brand">
             {keywords.map((keyword) => (
-              <span key={keyword} className="rounded-full bg-brand-light/60 px-3 py-1 text-brand-dark">
+              <span key={keyword} className="rounded-full border border-slate-700/80 bg-slate-950/80 px-3 py-1 text-slate-200">
                 {keyword}
               </span>
             ))}

--- a/src/components/WordOfDay.jsx
+++ b/src/components/WordOfDay.jsx
@@ -15,20 +15,25 @@ const WordOfDay = () => {
   const localizedSource = t(['words', word.id, 'source'], word.source);
 
   return (
-    <section className="rounded-3xl border border-brand/30 bg-brand-light/60 p-6">
-      <p className="text-xs font-semibold uppercase tracking-wide text-brand-dark">
-        {t('wordOfDay.eyebrow', 'Word of the Day')}
-      </p>
-      <h3 className="mt-2 text-2xl font-display font-semibold text-brand-dark">{localizedTerm}</h3>
-      <p className="mt-3 text-sm text-slate-700">{localizedDefinition}</p>
-      <p className="mt-2 text-sm italic text-brand-dark/80">
-        {t('wordOfDay.example', `Example: {example}`, { example: localizedExample })}
-      </p>
-      {localizedSource && (
-        <p className="mt-2 text-xs text-slate-500">
-          {t('wordOfDay.definitionSource', 'Definition adapted from {source}.', { source: localizedSource })}
+    <section className="relative overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-lg shadow-slate-950/40">
+      <div className="pointer-events-none absolute inset-0 opacity-70" aria-hidden>
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(56,189,248,0.3),transparent_60%)]" />
+      </div>
+      <div className="relative z-10">
+        <p className="text-xs font-semibold uppercase tracking-wide text-brand/80">
+          {t('wordOfDay.eyebrow', 'Word of the Day')}
         </p>
-      )}
+        <h3 className="mt-2 text-2xl font-display font-semibold text-white">{localizedTerm}</h3>
+        <p className="mt-3 text-sm text-slate-300">{localizedDefinition}</p>
+        <p className="mt-2 text-sm italic text-brand/80">
+          {t('wordOfDay.example', `Example: {example}`, { example: localizedExample })}
+        </p>
+        {localizedSource && (
+          <p className="mt-2 text-xs text-slate-500">
+            {t('wordOfDay.definitionSource', 'Definition adapted from {source}.', { source: localizedSource })}
+          </p>
+        )}
+      </div>
     </section>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -3,9 +3,47 @@
 @tailwind utilities;
 
 body {
-  @apply bg-slate-50 text-slate-800;
+  @apply min-h-screen bg-slate-950 text-slate-100 antialiased;
+  background-image: radial-gradient(circle at 0% -20%, rgba(56, 189, 248, 0.15), transparent 45%),
+    radial-gradient(circle at 100% 120%, rgba(15, 23, 42, 0.9), #020617 75%);
+  background-attachment: fixed;
 }
 
 img {
   @apply rounded-xl;
+}
+
+@layer utilities {
+  .text-slate-900 {
+    @apply text-slate-100;
+  }
+
+  .text-slate-800 {
+    @apply text-slate-200;
+  }
+
+  .text-slate-700,
+  .text-slate-600 {
+    @apply text-slate-300;
+  }
+
+  .text-slate-500 {
+    @apply text-slate-400;
+  }
+
+  .bg-white {
+    @apply bg-slate-900/70;
+  }
+
+  .bg-slate-50 {
+    @apply bg-slate-950/60;
+  }
+
+  .border-slate-200 {
+    @apply border-slate-800/70;
+  }
+
+  .border-slate-300 {
+    @apply border-slate-800/60;
+  }
 }

--- a/src/pages/AboutPage.jsx
+++ b/src/pages/AboutPage.jsx
@@ -11,26 +11,30 @@ const AboutPage = () => {
   return (
     <div className="mx-auto max-w-4xl space-y-8 px-4 py-10">
       <header className="space-y-3">
-        <p className="text-xs font-semibold uppercase tracking-wide text-brand-dark">
+        <p className="text-xs font-semibold uppercase tracking-wide text-brand/80">
           {t('aboutPage.eyebrow', 'About')}
         </p>
-        <h1 className="text-3xl font-display font-semibold text-slate-900">{t('aboutPage.heading', 'Our mission')}</h1>
+        <h1 className="text-3xl font-display font-semibold text-white">{t('aboutPage.heading', 'Our mission')}</h1>
       </header>
-      <section className="space-y-4 rounded-3xl bg-white p-6 shadow">
-        <p className="text-sm leading-7 text-slate-700">{t(
-          'aboutPage.description1',
-          'SciBridge supports high school students who study Natural Sciences in English. We combine accurate science content with friendly explanations, vocabulary supports, and multimedia to build confidence. Each lesson is written with simple academic language so English learners can participate fully in science classes.'
-        )}</p>
-        <p className="text-sm leading-7 text-slate-700">{t(
-          'aboutPage.description2',
-          'Our teaching team includes science educators, language specialists, and designers. Together we create flexible learning modules that teachers can use in class or students can explore independently.'
-        )}</p>
+      <section className="space-y-4 rounded-3xl border border-slate-800/70 bg-slate-900/70 p-6 text-slate-300 shadow-lg shadow-slate-950/40">
+        <p className="text-sm leading-7">
+          {t(
+            'aboutPage.description1',
+            'SciBridge supports high school students who study Natural Sciences in English. We combine accurate science content with friendly explanations, vocabulary supports, and multimedia to build confidence. Each lesson is written with simple academic language so English learners can participate fully in science classes.'
+          )}
+        </p>
+        <p className="text-sm leading-7">
+          {t(
+            'aboutPage.description2',
+            'Our teaching team includes science educators, language specialists, and designers. Together we create flexible learning modules that teachers can use in class or students can explore independently.'
+          )}
+        </p>
       </section>
-      <section className="space-y-4 rounded-3xl border border-brand/30 bg-brand-light/60 p-6">
-        <h2 className="text-xl font-display font-semibold text-brand-dark">
+      <section className="space-y-4 rounded-3xl border border-brand/40 bg-brand/10 p-6 text-slate-200 shadow-lg shadow-slate-950/40">
+        <h2 className="text-xl font-display font-semibold text-white">
           {t('aboutPage.expandHeading', 'How to expand this site')}
         </h2>
-        <ul className="list-disc space-y-2 pl-6 text-sm text-slate-700">
+        <ul className="list-disc space-y-2 pl-6 text-sm text-slate-200">
           {expandList.map((item, index) => (
             <li key={index}>{item}</li>
           ))}

--- a/src/pages/ContactPage.jsx
+++ b/src/pages/ContactPage.jsx
@@ -5,69 +5,69 @@ const ContactPage = () => {
   return (
     <div className="mx-auto max-w-4xl space-y-8 px-4 py-10">
       <header className="space-y-3">
-        <p className="text-xs font-semibold uppercase tracking-wide text-brand-dark">
+        <p className="text-xs font-semibold uppercase tracking-wide text-brand/80">
           {t('contactPage.eyebrow', 'Contact')}
         </p>
-        <h1 className="text-3xl font-display font-semibold text-slate-900">
+        <h1 className="text-3xl font-display font-semibold text-white">
           {t('contactPage.heading', 'Connect with the SciBridge team')}
         </h1>
       </header>
       <section className="grid gap-6 md:grid-cols-2">
-        <div className="space-y-4 rounded-3xl bg-white p-6 shadow">
-          <h2 className="text-xl font-semibold text-slate-900">{t('contactPage.formTitle', 'Send us a message')}</h2>
-          <p className="text-sm text-slate-600">
+        <div className="space-y-4 rounded-3xl border border-slate-800/70 bg-slate-900/70 p-6 shadow-lg shadow-slate-950/40">
+          <h2 className="text-xl font-semibold text-white">{t('contactPage.formTitle', 'Send us a message')}</h2>
+          <p className="text-sm text-slate-300">
             {t(
               'contactPage.formDescription',
               'Share feedback, ask for lesson ideas, or tell us how you use SciBridge in your classroom.'
             )}
           </p>
           <form className="space-y-4">
-            <label className="block text-sm">
-              <span className="text-slate-600">{t('contactPage.nameLabel', 'Name')}</span>
+            <label className="block text-sm text-slate-300">
+              <span className="text-slate-300">{t('contactPage.nameLabel', 'Name')}</span>
               <input
                 type="text"
-                className="mt-1 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-2 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30"
+                className="mt-1 w-full rounded-2xl border border-slate-800 bg-slate-950/60 px-4 py-2 text-slate-100 placeholder:text-slate-500 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/40"
                 placeholder={t('contactPage.namePlaceholder', 'Your full name')}
               />
             </label>
-            <label className="block text-sm">
-              <span className="text-slate-600">{t('contactPage.emailLabel', 'Email')}</span>
+            <label className="block text-sm text-slate-300">
+              <span className="text-slate-300">{t('contactPage.emailLabel', 'Email')}</span>
               <input
                 type="email"
-                className="mt-1 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-2 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30"
+                className="mt-1 w-full rounded-2xl border border-slate-800 bg-slate-950/60 px-4 py-2 text-slate-100 placeholder:text-slate-500 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/40"
                 placeholder={t('contactPage.emailPlaceholder', 'you@example.com')}
               />
             </label>
-            <label className="block text-sm">
-              <span className="text-slate-600">{t('contactPage.messageLabel', 'Message')}</span>
+            <label className="block text-sm text-slate-300">
+              <span className="text-slate-300">{t('contactPage.messageLabel', 'Message')}</span>
               <textarea
                 rows="4"
-                className="mt-1 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-2 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30"
+                className="mt-1 w-full rounded-2xl border border-slate-800 bg-slate-950/60 px-4 py-2 text-slate-100 placeholder:text-slate-500 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/40"
                 placeholder={t('contactPage.messagePlaceholder', 'How can we help?')}
               />
             </label>
             <button
               type="button"
-              className="w-full rounded-full bg-brand px-4 py-3 text-sm font-semibold text-white shadow hover:bg-brand-dark"
+              className="w-full rounded-full bg-brand px-4 py-3 text-sm font-semibold text-white shadow-[0_12px_30px_rgba(56,189,248,0.3)] transition hover:bg-brand-dark"
             >
               {t('contactPage.submit', 'Send message')}
             </button>
           </form>
         </div>
-        <div className="space-y-4 rounded-3xl border border-brand/30 bg-brand-light/60 p-6">
-          <h2 className="text-xl font-semibold text-brand-dark">{t('contactPage.quickInfoTitle', 'Quick information')}</h2>
-          <div className="space-y-3 text-sm text-slate-700">
+        <div className="space-y-4 rounded-3xl border border-brand/40 bg-brand/10 p-6 text-slate-200 shadow-lg shadow-slate-950/40">
+          <h2 className="text-xl font-semibold text-white">{t('contactPage.quickInfoTitle', 'Quick information')}</h2>
+          <div className="space-y-3 text-sm">
             <p>
-              <strong>Email:</strong> hello@scibridge.edu
+              <strong className="text-slate-100">Email:</strong> hello@scibridge.edu
             </p>
             <p>
-              <strong>Phone:</strong> +1 (555) 123-4567
+              <strong className="text-slate-100">Phone:</strong> +1 (555) 123-4567
             </p>
             <p>
-              <strong>{t('contactPage.officeHours', 'Office hours')}:</strong> Monday – Friday, 09:00 – 17:00 (GMT)
+              <strong className="text-slate-100">{t('contactPage.officeHours', 'Office hours')}:</strong> Monday – Friday, 09:00 – 17:00 (GMT)
             </p>
             <p>
-              <strong>{t('contactPage.community', 'Community')}:</strong> {t(
+              <strong className="text-slate-100">{t('contactPage.community', 'Community')}:</strong> {t(
                 'contactPage.communityText',
                 'Join the SciBridge teachers forum to share ideas and best practices.'
               )}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -16,32 +16,34 @@ const HomePage = () => {
   return (
     <div className="space-y-16">
       <Hero />
-      <section className="mx-auto max-w-6xl px-4">
-        <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-wide text-brand-dark">
-              {t('home.tracksEyebrow', 'Core and extension tracks')}
-            </p>
-            <h2 className="mt-2 text-2xl font-display font-semibold text-slate-900">
-              {t('home.tracksHeading', 'Lead with English, then explore science extensions')}
-            </h2>
-            <p className="mt-2 max-w-2xl text-sm text-slate-600">
-              {t(
-                'home.tracksDescription',
-                'Begin with the English for Science track to practice vocabulary, grammar, and presentation phrases. When you feel confident, continue to the extension modules for Physics, Chemistry, Biology, and Earth Science—each includes visuals, videos, and key terms in learner-friendly English.'
-              )}
-            </p>
+      <section className="mx-auto max-w-7xl px-4">
+        <div className="rounded-3xl border border-slate-800/70 bg-slate-900/60 p-8 shadow-lg shadow-slate-950/40">
+          <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-brand/80">
+                {t('home.tracksEyebrow', 'Core and extension tracks')}
+              </p>
+              <h2 className="mt-2 text-2xl font-display font-semibold text-white">
+                {t('home.tracksHeading', 'Lead with English, then explore science extensions')}
+              </h2>
+              <p className="mt-2 max-w-2xl text-sm text-slate-300">
+                {t(
+                  'home.tracksDescription',
+                  'Begin with the English for Science track to practice vocabulary, grammar, and presentation phrases. When you feel confident, continue to the extension modules for Physics, Chemistry, Biology, and Earth Science—each includes visuals, videos, and key terms in learner-friendly English.'
+                )}
+              </p>
+            </div>
+          </div>
+          <div className="mt-8 grid gap-6 md:grid-cols-2">
+            {subjects.map((subject) => (
+              <SubjectCard key={subject.id} subject={subject} />
+            ))}
           </div>
         </div>
-        <div className="mt-8 grid gap-6 md:grid-cols-2">
-          {subjects.map((subject) => (
-            <SubjectCard key={subject.id} subject={subject} />
-          ))}
-        </div>
       </section>
-      <section className="mx-auto grid max-w-6xl gap-6 px-4 md:grid-cols-[2fr,1fr]">
+      <section className="mx-auto grid max-w-7xl gap-6 px-4 md:grid-cols-[2fr,1fr]">
         <div className="space-y-6">
-          <p className="text-xs font-semibold uppercase tracking-wide text-brand-dark">
+          <p className="text-xs font-semibold uppercase tracking-wide text-brand/80">
             {t('home.practiceEyebrow', 'Interactive Practice')}
           </p>
           {featuredQuizzes.map((quiz) => (
@@ -53,12 +55,12 @@ const HomePage = () => {
           <ScienceChatbot />
         </div>
       </section>
-      <section className="mx-auto max-w-6xl px-4">
-        <div className="rounded-3xl bg-brand-light/60 p-8 shadow-sm">
-          <h2 className="text-2xl font-display font-semibold text-brand-dark">
+      <section className="mx-auto max-w-7xl px-4">
+        <div className="rounded-3xl border border-brand/30 bg-gradient-to-br from-brand/20 via-slate-900 to-slate-950 p-8 shadow-lg shadow-slate-950/40">
+          <h2 className="text-2xl font-display font-semibold text-white">
             {t('home.forumHeading', 'Practice English with classmates')}
           </h2>
-          <p className="mt-3 max-w-3xl text-sm text-slate-600">
+          <p className="mt-3 max-w-3xl text-sm text-slate-200">
             {t(
               'home.forumDescription',
               'Join the SciBridge Forum to post study updates, ask questions in English, and support other students in Physics, Chemistry, Biology, and Earth Science. Create an account, verify your email, and log in to share your voice safely.'
@@ -66,7 +68,7 @@ const HomePage = () => {
           </p>
           <Link
             to="/forum"
-            className="mt-6 inline-flex items-center gap-2 rounded-full bg-brand px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-dark"
+            className="mt-6 inline-flex items-center gap-2 rounded-full bg-brand px-6 py-2 text-sm font-semibold text-white shadow-[0_10px_30px_rgba(56,189,248,0.35)] transition hover:bg-brand-dark"
           >
             {t('home.forumCta', 'Visit the forum')}
           </Link>

--- a/src/pages/LessonPage.jsx
+++ b/src/pages/LessonPage.jsx
@@ -16,10 +16,13 @@ const LessonPage = ({ onComplete, progress }) => {
   if (!subject || !lesson) {
     return (
       <div className="mx-auto max-w-4xl px-4 py-20 text-center">
-        <h1 className="text-3xl font-display font-semibold text-slate-900">
+        <h1 className="text-3xl font-display font-semibold text-white">
           {t('lessonPage.notFoundTitle', 'Lesson not found')}
         </h1>
-        <Link to="/subjects" className="mt-6 inline-block rounded-full bg-brand px-6 py-3 text-sm font-semibold text-white">
+        <Link
+          to="/subjects"
+          className="mt-6 inline-block rounded-full bg-brand px-6 py-3 text-sm font-semibold text-white shadow-[0_10px_30px_rgba(56,189,248,0.35)] transition hover:bg-brand-dark"
+        >
           {t('lessonPage.backToSubjects', 'Back to subjects')}
         </Link>
       </div>
@@ -40,7 +43,7 @@ const LessonPage = ({ onComplete, progress }) => {
 
   return (
     <article className="mx-auto max-w-4xl space-y-10 px-4 py-10">
-      <nav className="text-sm text-slate-500">
+      <nav className="text-sm text-slate-400">
         <Link to="/subjects" className="text-brand hover:text-brand-dark">
           {t('lessonPage.breadcrumbSubjects', 'Subjects')}
         </Link>{' '}
@@ -48,39 +51,43 @@ const LessonPage = ({ onComplete, progress }) => {
         <Link to={`/subjects/${subject.id}`} className="text-brand hover:text-brand-dark">
           {subjectTitle}
         </Link>{' '}
-        / <span className="text-slate-700">{lessonTitle}</span>
+        / <span className="text-slate-300">{lessonTitle}</span>
       </nav>
       <header className="space-y-4">
-        <p className="text-xs font-semibold uppercase tracking-wide text-brand-dark">
+        <p className="text-xs font-semibold uppercase tracking-wide text-brand/80">
           {t('lessonPage.eyebrow', 'Lesson')}
         </p>
-        <h1 className="text-3xl font-display font-semibold text-slate-900">{lessonTitle}</h1>
-        <p className="text-base text-slate-600">{lessonSummary}</p>
+        <h1 className="text-3xl font-display font-semibold text-white">{lessonTitle}</h1>
+        <p className="text-base text-slate-300">{lessonSummary}</p>
         <div className="flex flex-wrap gap-2 text-xs text-brand">
           {keyVocabulary.map((word) => (
-            <span key={word} className="rounded-full bg-brand-light/60 px-3 py-1 text-brand-dark">
+            <span key={word} className="rounded-full border border-slate-700/80 bg-slate-950/80 px-3 py-1 text-slate-200">
               {word}
             </span>
           ))}
         </div>
       </header>
-      <img src={lesson.image} alt={lessonTitle} className="w-full object-cover" />
+      <img
+        src={lesson.image}
+        alt={lessonTitle}
+        className="w-full rounded-3xl border border-slate-800/70 object-cover"
+      />
       <section className="space-y-4">
-        <h2 className="text-xl font-display font-semibold text-slate-900">
+        <h2 className="text-xl font-display font-semibold text-white">
           {t('lessonPage.stepsHeading', 'Step-by-step explanation')}
         </h2>
-        <div className="space-y-3 rounded-3xl bg-white p-6 shadow">
+        <div className="space-y-3 rounded-3xl border border-slate-800/70 bg-slate-900/70 p-6 shadow-lg shadow-slate-950/40">
           {lessonContent.map((paragraph, index) => (
-            <p key={index} className="text-sm leading-7 text-slate-700">
+            <p key={index} className="text-sm leading-7 text-slate-300">
               {paragraph}
             </p>
           ))}
         </div>
       </section>
       <section className="grid gap-6 md:grid-cols-2">
-        <div className="space-y-3 rounded-3xl bg-slate-900 p-6 text-white">
+        <div className="space-y-3 rounded-3xl border border-slate-800/70 bg-slate-900/80 p-6 text-white shadow-lg shadow-slate-950/40">
           <h2 className="text-lg font-semibold">{t('lessonPage.videoHeading', 'Watch the mini lesson')}</h2>
-          <p className="text-sm text-slate-100">
+          <p className="text-sm text-slate-200">
             {t(
               'lessonPage.videoDescription',
               'Videos help you connect English words with science visuals. Use captions to support language learning.'
@@ -96,18 +103,22 @@ const LessonPage = ({ onComplete, progress }) => {
             />
           </div>
         </div>
-        <div className="space-y-3 rounded-3xl border border-brand/30 bg-white p-6">
-          <h2 className="text-lg font-semibold text-slate-900">{t('lessonPage.animationHeading', 'Animated concept')}</h2>
-          <p className="text-sm text-slate-600">
+        <div className="space-y-3 rounded-3xl border border-slate-800/70 bg-slate-900/70 p-6 text-slate-200 shadow-lg shadow-slate-950/40">
+          <h2 className="text-lg font-semibold text-white">{t('lessonPage.animationHeading', 'Animated concept')}</h2>
+          <p className="text-sm text-slate-300">
             {t('lessonPage.animationDescription', 'Use the animation to observe the scientific process in motion.')}
           </p>
-          <img src={lesson.animationUrl} alt={`${lessonTitle} animation`} className="h-64 w-full object-cover" />
+          <img
+            src={lesson.animationUrl}
+            alt={`${lessonTitle} animation`}
+            className="h-64 w-full rounded-2xl border border-slate-800/70 object-cover"
+          />
           <button
             onClick={() => onComplete(lesson.id)}
             className={`w-full rounded-full px-4 py-3 text-sm font-semibold transition ${
               isCompleted
-                ? 'bg-emerald-100 text-emerald-700'
-                : 'bg-brand text-white shadow hover:bg-brand-dark'
+                ? 'border border-emerald-400/60 bg-emerald-500/15 text-emerald-200'
+                : 'bg-brand text-white shadow-[0_10px_25px_rgba(56,189,248,0.25)] hover:bg-brand-dark'
             }`}
           >
             {isCompleted
@@ -116,9 +127,9 @@ const LessonPage = ({ onComplete, progress }) => {
           </button>
         </div>
       </section>
-      <section className="rounded-3xl bg-brand-light/60 p-6">
-        <h2 className="text-lg font-semibold text-brand-dark">{t('lessonPage.practiceHeading', 'Practice ideas')}</h2>
-        <ul className="mt-3 list-disc space-y-2 pl-6 text-sm text-slate-700">
+      <section className="rounded-3xl border border-brand/40 bg-brand/10 p-6 text-slate-200 shadow-lg shadow-slate-950/40">
+        <h2 className="text-lg font-semibold text-white">{t('lessonPage.practiceHeading', 'Practice ideas')}</h2>
+        <ul className="mt-3 list-disc space-y-2 pl-6 text-sm">
           {practiceIdeas.map((idea, index) => (
             <li key={index}>{idea}</li>
           ))}

--- a/src/pages/NotFoundPage.jsx
+++ b/src/pages/NotFoundPage.jsx
@@ -5,14 +5,14 @@ const NotFoundPage = () => {
   const { t } = useLanguage();
   return (
     <div className="mx-auto max-w-3xl px-4 py-20 text-center">
-      <h1 className="text-4xl font-display font-semibold text-slate-900">{t('notFound.title', 'Page not found')}</h1>
-      <p className="mt-4 text-sm text-slate-600">{t(
+      <h1 className="text-4xl font-display font-semibold text-white">{t('notFound.title', 'Page not found')}</h1>
+      <p className="mt-4 text-sm text-slate-300">{t(
         'notFound.description',
         'The page you are looking for does not exist. Use the navigation bar or explore our main subjects.'
       )}</p>
       <Link
         to="/"
-        className="mt-6 inline-block rounded-full bg-brand px-6 py-3 text-sm font-semibold text-white shadow hover:bg-brand-dark"
+        className="mt-6 inline-block rounded-full bg-brand px-6 py-3 text-sm font-semibold text-white shadow-[0_10px_30px_rgba(56,189,248,0.35)] transition hover:bg-brand-dark"
       >
         {t('notFound.backHome', 'Back to home')}
       </Link>

--- a/src/pages/QuizzesPage.jsx
+++ b/src/pages/QuizzesPage.jsx
@@ -7,13 +7,13 @@ const QuizzesPage = () => {
   return (
     <div className="mx-auto max-w-5xl space-y-10 px-4 py-10">
       <header className="space-y-4">
-        <p className="text-xs font-semibold uppercase tracking-wide text-brand-dark">
+        <p className="text-xs font-semibold uppercase tracking-wide text-brand/80">
           {t('quizzesPage.eyebrow', 'Interactive quizzes')}
         </p>
-        <h1 className="text-3xl font-display font-semibold text-slate-900">
+        <h1 className="text-3xl font-display font-semibold text-white">
           {t('quizzesPage.heading', 'Lead with English, review science')}
         </h1>
-        <p className="text-sm text-slate-600">
+        <p className="text-sm text-slate-300">
           {t(
             'quizzesPage.description',
             'Start with the English for Science Communication quiz, then try the extension quizzes for Physics, Chemistry, Biology, and Earth Science. Read each explanation to strengthen your academic English vocabulary.'

--- a/src/pages/ResourcesPage.jsx
+++ b/src/pages/ResourcesPage.jsx
@@ -33,13 +33,13 @@ const ResourcesPage = () => {
   return (
     <div className="mx-auto max-w-5xl space-y-10 px-4 py-10">
       <header className="space-y-4">
-        <p className="text-xs font-semibold uppercase tracking-wide text-brand-dark">
+        <p className="text-xs font-semibold uppercase tracking-wide text-brand/80">
           {t('resourcesPage.eyebrow', 'Resources')}
         </p>
-        <h1 className="text-3xl font-display font-semibold text-slate-900">
+        <h1 className="text-3xl font-display font-semibold text-white">
           {t('resourcesPage.heading', 'Extra study tools')}
         </h1>
-        <p className="text-sm text-slate-600">
+        <p className="text-sm text-slate-300">
           {t(
             'resourcesPage.description',
             'Explore safe websites that offer videos, animations, articles, and downloadable worksheets. Use these tools to review lessons or extend your learning in English.'

--- a/src/pages/SubjectDetailPage.jsx
+++ b/src/pages/SubjectDetailPage.jsx
@@ -17,13 +17,16 @@ const SubjectDetailPage = ({ progress, onComplete }) => {
   if (!subject) {
     return (
       <div className="mx-auto max-w-4xl px-4 py-20 text-center">
-        <h1 className="text-3xl font-display font-semibold text-slate-900">
+        <h1 className="text-3xl font-display font-semibold text-white">
           {t('subjectsPage.subjectNotFound', 'Subject not found')}
         </h1>
-        <p className="mt-3 text-sm text-slate-600">
+        <p className="mt-3 text-sm text-slate-300">
           {t('subjectsPage.subjectNotFoundMessage', 'Please return to the subjects page and choose a different topic.')}
         </p>
-        <Link to="/subjects" className="mt-6 inline-block rounded-full bg-brand px-6 py-3 text-sm font-semibold text-white">
+        <Link
+          to="/subjects"
+          className="mt-6 inline-block rounded-full bg-brand px-6 py-3 text-sm font-semibold text-white shadow-[0_10px_30px_rgba(56,189,248,0.35)] transition hover:bg-brand-dark"
+        >
           {t('lessonPage.backToSubjects', 'Back to subjects')}
         </Link>
       </div>
@@ -35,15 +38,16 @@ const SubjectDetailPage = ({ progress, onComplete }) => {
 
   return (
     <div className="mx-auto max-w-5xl space-y-10 px-4">
-      <header className="relative overflow-hidden rounded-3xl bg-cover bg-center p-10 text-white shadow-lg"
-        style={{ backgroundImage: `linear-gradient(120deg, rgba(14,165,233,0.8), rgba(236,72,153,0.7)), url(${subject.heroImage})` }}
+      <header
+        className="relative overflow-hidden rounded-3xl border border-slate-800/60 bg-cover bg-center p-10 text-white shadow-[0_35px_120px_-40px_rgba(2,6,23,0.9)]"
+        style={{ backgroundImage: `linear-gradient(120deg, rgba(14,165,233,0.75), rgba(8,47,73,0.85)), url(${subject.heroImage})` }}
       >
-        <p className="text-xs font-semibold uppercase tracking-[0.3em]">{badgeLabel}</p>
+        <p className="text-xs font-semibold uppercase tracking-[0.35em] text-brand/80">{badgeLabel}</p>
         <h1 className="mt-3 text-4xl font-display font-semibold">{title}</h1>
-        <p className="mt-4 max-w-2xl text-sm text-slate-100">{overview}</p>
+        <p className="mt-4 max-w-2xl text-sm text-slate-100/90">{overview}</p>
       </header>
       <section className="space-y-6">
-        <h2 className="text-2xl font-display font-semibold text-slate-900">
+        <h2 className="text-2xl font-display font-semibold text-white">
           {t('subjectsPage.lessonCollection', 'Lesson collection')}
         </h2>
         <div className="space-y-6">

--- a/src/pages/SubjectsPage.jsx
+++ b/src/pages/SubjectsPage.jsx
@@ -28,15 +28,15 @@ const SubjectsPage = ({ query, setQuery, progress, onComplete, onResetProgress }
     : [];
 
   return (
-    <div className="mx-auto max-w-6xl space-y-12 px-4">
+    <div className="mx-auto max-w-7xl space-y-12 px-4">
       <header className="space-y-4 pt-8">
-        <p className="text-xs font-semibold uppercase tracking-wide text-brand-dark">
+        <p className="text-xs font-semibold uppercase tracking-wide text-brand/80">
           {t('subjectsPage.eyebrow', 'Learn by topic')}
         </p>
-        <h1 className="text-3xl font-display font-semibold text-slate-900">
+        <h1 className="text-3xl font-display font-semibold text-white">
           {t('subjectsPage.heading', 'English core lessons and science extensions')}
         </h1>
-        <p className="text-sm text-slate-600">
+        <p className="text-sm text-slate-300">
           {t(
             'subjectsPage.description',
             'Search the English for Science lessons first, then explore extension modules in Physics, Chemistry, Biology, and Earth Science. Explanations use simple academic English to support multilingual learners.'
@@ -55,8 +55,8 @@ const SubjectsPage = ({ query, setQuery, progress, onComplete, onResetProgress }
       <div className="grid gap-6 md:grid-cols-[2fr,1fr]">
         <div className="space-y-6">
           {normalizedQuery && (
-            <section className="space-y-4 rounded-3xl border border-brand/30 bg-white p-6 shadow-sm">
-              <h2 className="text-lg font-semibold text-slate-900">
+            <section className="space-y-4 rounded-3xl border border-slate-800/70 bg-slate-900/70 p-6 shadow-lg shadow-slate-950/40">
+              <h2 className="text-lg font-semibold text-white">
                 {filteredLessons.length === 1
                   ? t('subjectsPage.resultsSingular', `Found {count} lesson`, { count: filteredLessons.length })
                   : t('subjectsPage.resultsPlural', `Found {count} lessons`, { count: filteredLessons.length })}
@@ -76,7 +76,7 @@ const SubjectsPage = ({ query, setQuery, progress, onComplete, onResetProgress }
           )}
 
           <section className="space-y-4">
-            <h2 className="text-lg font-semibold text-slate-900">
+            <h2 className="text-lg font-semibold text-white">
               {t('subjectsPage.browseHeading', 'Browse English core + science extensions')}
             </h2>
             <div className="grid gap-6 md:grid-cols-2">


### PR DESCRIPTION
## Summary
- restyle the layout with a dark, oj.vnoi.info-inspired theme while preserving the existing SciBridge brand colors
- refresh shared components and subject/lesson pages to use the new aesthetic and improve readability on the darker backdrop
- add global utility overrides so legacy slate color classes render appropriately in the updated theme

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e86a91f0a0833189982d0c98216836