### PR TITLE
Add lesson deletion controls

### DIFF
--- a/src/pages/AdminPanelPage.jsx
+++ b/src/pages/AdminPanelPage.jsx
@@ -26,7 +26,8 @@ import {
   addLearningTrack,
   addLesson,
   addQuizQuestion,
-  getLearningTracks
+  getLearningTracks,
+  removeLesson
 } from '../services/learningTrackService.js';
 import WPAdminToolbar from '../components/WPAdminToolbar.jsx';
 
@@ -498,6 +499,23 @@ const AdminPanelPage = ({ user, onProfileUpdate, onLogout }) => {
       );
       setQuizDraft({ ...defaultQuizDraft, trackId: updatedTrack.id });
       handleSuccess('Quiz question added to this lesson.');
+    } catch (error) {
+      handleError(error.message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleLessonDelete = (trackId, chapterId, lessonId) => {
+    if (!trackId || !chapterId || !lessonId) {
+      handleError('Không thể xóa lesson vì thiếu thông tin khối hoặc chapter.');
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      const updatedTracks = removeLesson(trackId, chapterId, lessonId);
+      setLearningTracks(updatedTracks);
+      handleSuccess('Đã xóa lesson khỏi chapter.');
     } catch (error) {
       handleError(error.message);
     } finally {
@@ -1362,8 +1380,19 @@ const AdminPanelPage = ({ user, onProfileUpdate, onLogout }) => {
                                 </div>
                                 <ul className="mt-1 space-y-1 text-xs text-slate-700">
                                   {(chapter.lessons || []).map((lesson) => (
-                                    <li key={lesson.id} className="rounded bg-slate-50 px-2 py-1">
-                                      <span className="font-semibold text-brand">{lesson.title}</span> · VOCAB | PRACTICE | DIALOGUE
+                                    <li key={lesson.id} className="flex items-center justify-between gap-2 rounded bg-slate-50 px-2 py-1">
+                                      <div className="space-y-0.5">
+                                        <p className="font-semibold text-brand">{lesson.title}</p>
+                                        <p>VOCAB | PRACTICE | DIALOGUE</p>
+                                      </div>
+                                      <button
+                                        type="button"
+                                        onClick={() => handleLessonDelete(track.id, chapter.id, lesson.id)}
+                                        className="inline-flex items-center justify-center gap-1 rounded-md bg-rose-50 px-2 py-1 text-[11px] font-semibold text-rose-700 shadow-sm transition hover:bg-rose-100 disabled:cursor-not-allowed disabled:opacity-60"
+                                        disabled={isSubmitting}
+                                      >
+                                        Xóa lesson
+                                      </button>
                                     </li>
                                   ))}
                                 </ul>

--- a/src/services/learningTrackService.js
+++ b/src/services/learningTrackService.js
@@ -271,6 +271,23 @@ export function addQuizQuestion(trackId, question) {
   return updated.find((track) => track.id === trackId);
 }
 
+export function removeLesson(trackId, chapterId, lessonId) {
+  const tracks = readFromStorage();
+  const updated = tracks.map((track) => {
+    if (track.id !== trackId) return track;
+    const chapters = (track.chapters || []).map((chapter) => {
+      if (chapter.id !== chapterId) return chapter;
+      return {
+        ...chapter,
+        lessons: (chapter.lessons || []).filter((lesson) => lesson.id !== lessonId)
+      };
+    });
+    return { ...track, chapters };
+  });
+  persist(updated);
+  return updated;
+}
+
 export function clearLearningTracks() {
   if (!isBrowser) return;
   window.localStorage.removeItem(STORAGE_KEY);


### PR DESCRIPTION
## Summary
- add a learningTrackService helper to remove lessons from stored grade content
- allow admins to delete lessons directly from the Published grade content list with feedback
- keep admin panel state in sync after lesson removal

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944310f692883298b97011588ba5f16)